### PR TITLE
Provide python 3 compatibility

### DIFF
--- a/parler/appsettings.py
+++ b/parler/appsettings.py
@@ -3,6 +3,7 @@ Overview of all settings which can be customized.
 """
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils import six
 from parler.utils import normalize_language_code, is_supported_django_language
 from parler.utils.conf import LanguagesSetting
 
@@ -51,7 +52,7 @@ def add_default_language_settings(languages_list, var_name='PARLER_LANGUAGES', *
     if not is_supported_django_language(defaults['code']):
         raise ImproperlyConfigured("The value for {0}['defaults']['code'] ('{1}') does not exist in LANGUAGES".format(var_name, defaults['code']))
 
-    for site_id, lang_choices in languages_list.iteritems():
+    for site_id, lang_choices in six.iteritems(languages_list):
         if site_id == 'default':
             continue
 
@@ -62,7 +63,7 @@ def add_default_language_settings(languages_list, var_name='PARLER_LANGUAGES', *
                 raise ImproperlyConfigured("{0}[{1}][{2}]['code'] does not exist in LANGUAGES".format(var_name, site_id, i))
 
             # Copy all items from the defaults, so you can provide new fields too.
-            for key, value in defaults.iteritems():
+            for key, value in six.iteritems(defaults):
                 choice.setdefault(key, value)
 
     return languages_list

--- a/parler/cache.py
+++ b/parler/cache.py
@@ -24,7 +24,7 @@ def get_translation_cache_key(translated_model, master_id, language_code):
     """
     # Always cache the entire object, as this already produces
     # a lot of queries. Don't go for caching individual fields.
-    return 'parler.{0}.{1}.{2}'.format(translated_model.__name__, long(master_id), language_code)
+    return 'parler.{0}.{1}.{2}'.format(translated_model.__name__, int(master_id), language_code)
 
 
 def get_cached_translation(instance, language_code, use_fallback=False):

--- a/parler/models.py
+++ b/parler/models.py
@@ -16,6 +16,7 @@ from django.db.models.base import ModelBase
 from django.db.models.fields.related import ReverseSingleRelatedObjectDescriptor
 from django.utils.functional import lazy
 from django.utils.translation import get_language, ugettext
+from django.utils import six
 from parler import signals
 from parler.cache import _cache_translation, _cache_translation_needs_fallback, _delete_cached_translation, get_cached_translation, _delete_cached_translations, get_cached_translated_field
 from parler.fields import TranslatedField, LanguageCodeDescriptor, TranslatedFieldDescriptor
@@ -37,7 +38,7 @@ class TranslationDoesNotExist(AttributeError):
     pass
 
 
-_lazy_verbose_name = lazy(lambda x: ugettext("{0} Translation").format(x._meta.verbose_name), unicode)
+_lazy_verbose_name = lazy(lambda x: ugettext("{0} Translation").format(x._meta.verbose_name), six.text_type)
 
 
 def create_translations_model(shared_model, related_name, meta, **fields):
@@ -159,7 +160,7 @@ class TranslatableModel(models.Model):
         # Assign translated args manually.
         if translated_kwargs:
             translation = self._get_translated_model(auto_create=True)
-            for field, value in translated_kwargs.iteritems():
+            for field, value in six.iteritems(translated_kwargs):
                 setattr(translation, field, value)
 
 
@@ -312,7 +313,7 @@ class TranslatableModel(models.Model):
             try:
                 return self._translations_cache.get(self._current_language, None) \
                     or self._translations_cache.get(self.get_fallback_language(), None) \
-                    or next(t for t in self._translations_cache.itervalues() if t if not None)  # Skip fallback markers.
+                    or next(t for t in six.itervalues(self._translations_cache) if t if not None)  # Skip fallback markers.
             except StopIteration:
                 pass
 
@@ -339,7 +340,7 @@ class TranslatableModel(models.Model):
     def save_translations(self, *args, **kwargs):
         # Save all translated objects which were fetched.
         # This also supports switching languages several times, and save everything in the end.
-        for translation in self._translations_cache.itervalues():
+        for translation in six.itervalues(self._translations_cache):
             if translation is None:  # Skip fallback markers
                 continue
 

--- a/parler/tests/forms.py
+++ b/parler/tests/forms.py
@@ -17,8 +17,8 @@ class FormTests(AppTestCase):
         """
         Check if the form fields exist.
         """
-        self.assertTrue(SimpleForm.base_fields.has_key('shared'))
-        self.assertTrue(SimpleForm.base_fields.has_key('tr_title'))
+        self.assertTrue('shared' in SimpleForm.base_fields)
+        self.assertTrue('tr_title' in SimpleForm.base_fields)
 
 
     def test_form_save(self):

--- a/parler/tests/utils.py
+++ b/parler/tests/utils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.management import call_command
@@ -26,7 +27,7 @@ class AppTestCase(TestCase):
             run_syncdb = False
             for appname in cls.install_apps:
                 if appname not in settings.INSTALLED_APPS:
-                    print 'Adding {0} to INSTALLED_APPS'.format(appname)
+                    print('Adding {0} to INSTALLED_APPS'.format(appname))
                     settings.INSTALLED_APPS = (appname,) + tuple(settings.INSTALLED_APPS)
                     run_syncdb = True
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     license='Apache License, Version 2.0',
 
     requires=[
-        'Django (>=1.4)',
+        'Django (>=1.4.2)',
     ],
 
     description='Simple Django model translations without nasty hacks, featuring nice admin integration.',


### PR DESCRIPTION
The codebase is now compatible with python2.7 and python3.3
I used the customized version of six bundled with Django as of version 1.4.2.

The tests are still ok for python2.7 + django 1.5.5.
**But 3 are failing in python3.3**

I will try to investigate, but explore it yourself, you should be faster than me !

There may be a final step in adding `from __future__ import unicode_literals` for better compatibility.
