### PR TITLE
Make settings.SITE_ID optional

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Released on 1.0a1:
 * Added ``switch_language()`` context manager.
 * Added ``get_fallback_language()`` to result of ``add_default_language_settings()`` function.
 * Added partial support for tabs on inlines when the parent object isn't a translated model.
+* Make settings.SITE_ID setting optional
 * Fix inefficient or unneeded queries, i.e. for new objects.
 * Fix supporting different database (using=) arguments.
 * Fix list language, always show translated values.

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,23 @@ The fallback language can be changed in the settings::
 Optionally, the admin tabs can be configured too::
 
     PARLER_LANGUAGES = {
+        None: (
+            {'code': 'en',},
+            {'code': 'en-us',},
+            {'code': 'it',},
+            {'code': 'nl',},
+        ),
+        'default': {
+            'fallback': 'en',             # defaults to PARLER_DEFAULT_LANGUAGE_CODE
+            'hide_untranslated': False,   # the default; let .active_translations() return fallbacks too.
+        }
+    }
+
+When using ``settings.SITE_ID`` which is a setting of the sites framework
+(``django.contrib.sites``) the ``PARLER_LANGUAGES`` dict can contain
+site specific settings and the special ``None`` key is no longer used::
+
+    PARLER_LANGUAGES = {
         # Global site
         1: (
             {'code': 'en',},

--- a/parler/admin.py
+++ b/parler/admin.py
@@ -103,7 +103,8 @@ class BaseTranslatableAdmin(BaseModelAdmin):
 
     def _get_first_tab_language(self):
         try:
-            lang_choices = appsettings.PARLER_LANGUAGES[settings.SITE_ID]
+            site_id = getattr(settings, 'SITE_ID', None)
+            lang_choices = appsettings.PARLER_LANGUAGES[site_id]
             code = lang_choices[0]['code']
         except (KeyError, IndexError):
             # No configuration, always fallback to default language.
@@ -165,7 +166,8 @@ class BaseTranslatableAdmin(BaseModelAdmin):
 
         base_url = '{0}://{1}{2}'.format(request.is_secure() and 'https' or 'http', request.get_host(), request.path)
 
-        for lang_dict in appsettings.PARLER_LANGUAGES.get(settings.SITE_ID, ()):
+        site_id = getattr(settings, 'SITE_ID', None)
+        for lang_dict in appsettings.PARLER_LANGUAGES.get(site_id, ()):
             code = lang_dict['code']
             title = get_language_title(code)
             get['language'] = code

--- a/parler/utils/conf.py
+++ b/parler/utils/conf.py
@@ -17,7 +17,7 @@ class LanguagesSetting(dict):
         For an example, see :func:`~parler.appsettings.add_default_language_settings`.
         """
         if site_id is None:
-            site_id = settings.SITE_ID
+            site_id = getattr(settings, 'SITE_ID', None)
 
         for lang_dict in self.get(site_id, ()):
             if lang_dict['code'] == language_code:

--- a/parler/utils/i18n.py
+++ b/parler/utils/i18n.py
@@ -74,5 +74,5 @@ def is_multilingual_project(site_id=None):
     """
     from parler import appsettings
     if site_id is None:
-        site_id = settings.SITE_ID
+        site_id = getattr(settings, 'SITE_ID', None)
     return appsettings.PARLER_SHOW_EXCLUDED_LANGUAGE_TABS or site_id in appsettings.PARLER_LANGUAGES


### PR DESCRIPTION
Django 1.6 no longer includes a `SITE_ID` in the defaut project settings created with `manage.py startproject`. As parler does not really use anything of the sites framework besides the `SITE_ID` I simply added a fallback to the `None` value.

I updated the `README.rst` and `CHANGES.rst` accordingly.
