### PR TITLE
Use the app name when building the cache key

### DIFF
--- a/parler/cache.py
+++ b/parler/cache.py
@@ -28,7 +28,7 @@ def get_translation_cache_key(translated_model, master_id, language_code):
     """
     # Always cache the entire object, as this already produces
     # a lot of queries. Don't go for caching individual fields.
-    return 'parler.{0}.{1}.{2}'.format(translated_model.__name__, long(master_id), language_code)
+    return 'parler.{0}.{1}.{2}.{3}'.format(translated_model._meta.app_label, translated_model.__name__, long(master_id), language_code)
 
 
 def get_cached_translation(instance, language_code, use_fallback=False):


### PR DESCRIPTION
We have legacy code that has models of the same name (different fields) in multiple apps.

In this scenario, whichever model was loaded first would be in the cache. When viewing a page for the non-cached model, there would be a 500 error.

Also, thank you for parler!!
