### PR TITLE
Correct test using __func__ in python 3

### DIFF
--- a/parler/views.py
+++ b/parler/views.py
@@ -290,7 +290,9 @@ class TranslatableModelFormMixin(LanguageChoiceMixin):
         Return a ``TranslatableModelForm`` by default if no form_class is set.
         """
         super_method = super(TranslatableModelFormMixin, self).get_form_class
-        if not (super_method.__func__ is ModelFormMixin.get_form_class.__func__):
+        # no "__func__" on the class level function in python 3
+        default_method = getattr(ModelFormMixin.get_form_class, '__func__', ModelFormMixin.get_form_class)
+        if not (super_method.__func__ is default_method):
             # Don't get in your way, if you've overwritten stuff.
             return super_method()
         else:


### PR DESCRIPTION
On py3, the class level function doesn't have a `__func__`
property, it can be checked directly.

So the logic in pseudo code is:

``` python
    if is_py3:
        default_method == SomeClass.method
    else:
        default_method == SomeClass.method.__func__

    if not (super_method.__func__ is default_method):
      ...
```

I prefered to use `getattr` to avoid checking python version:

``` python
    getattr(SomeClass.method, '__func__', SomeClass.method)
```

=> if the class level function has a `__func__` attribute, use it,
   else use it directly
