### PR TITLE
Fix safe_translation_getter not fallbacking

### DIFF
--- a/parler/models.py
+++ b/parler/models.py
@@ -648,7 +648,7 @@ class TranslatableModel(models.Model):
         # Extra feature: query a single field from a other translation.
         if language_code and language_code != self._current_language:
             try:
-                tr_model = self._get_translated_model(language_code, meta=meta)
+                tr_model = self._get_translated_model(language_code, meta=meta, use_fallback=True)
                 return getattr(tr_model, field)
             except TranslationDoesNotExist:
                 pass

--- a/parler/tests/model_attributes.py
+++ b/parler/tests/model_attributes.py
@@ -138,6 +138,18 @@ class ModelAttributeTests(AppTestCase):
             x = SimpleModel.objects.get(pk=x.pk)
             self.assertEqual(x.tr_title, 'TITLE_FALLBACK')
 
+    def test_fallback_language_no_current(self):
+        """
+        Test whether the fallback language will be returned,
+        even when the current language does not have a translation.
+        """
+        x = SimpleModel()
+        x.set_current_language(self.conf_fallback)
+        x.tr_title = "TITLE_FALLBACK"
+
+        self.assertEqual(
+            x.safe_translation_getter('tr_title', language_code=self.other_lang1),
+            'TITLE_FALLBACK')
 
     def test_any_fallback_model(self):
         """


### PR DESCRIPTION
When the current_language does not have a translation

Fixes #47
