### PR TITLE
Document `meta` parameter for `TranslatedFields`.

### DIFF
--- a/parler/models.py
+++ b/parler/models.py
@@ -202,6 +202,21 @@ class TranslatedFields(object):
     ..
        To fetch the attribute, you can also query the Parler metadata:
        MyModel._parler_meta.get_model_by_related_name('translations')
+
+    :param meta: A dictionary of `Meta` options, passed to the :class:`TranslatedFieldsModel`
+        instance.
+
+        Example:
+
+        .. code-block:: python
+
+            class MyModel(TranslatableModel):
+                translations = TranslatedFields(
+                    title = models.CharField("Title", max_length=200),
+                    slug = models.SlugField("Slug"),
+                    meta = {'unique_together': [('language_code', 'slug')]},
+                )
+
     """
 
     def __init__(self, meta=None, **fields):


### PR DESCRIPTION
The `meta` parameter of `TranslatedFields` is currently largely undocumented. However, it is crucial e.g. for adding `unique_together` constraints which are often required for slugs. This adds documentation of the parameter along with an example. This should make sure it shows up through searches for "unique_together" or "slug".

I am not completely sure how parameters for `__init__` should be documented within parler, since I could not find any precedence. If it should be done differently, please let me know.

See also the discussion in #4.