### PR TITLE
Adds settings to change Django's `get_language` behavior.

### DIFF
--- a/parler/appsettings.py
+++ b/parler/appsettings.py
@@ -30,3 +30,6 @@ PARLER_LANGUAGES['default'].setdefault('fallbacks', [PARLER_DEFAULT_LANGUAGE_COD
 # Cleanup settings
 PARLER_DEFAULT_LANGUAGE_CODE = normalize_language_code(PARLER_DEFAULT_LANGUAGE_CODE)
 PARLER_LANGUAGES = add_default_language_settings(PARLER_LANGUAGES)
+
+# Activate translations by default. Flag to compensate for Django >= 1.8 default `get_language` behavior
+PARLER_DEFAULT_ACTIVATE = getattr(settings, 'PARLER_DEFAULT_ACTIVATE', False)

--- a/parler/models.py
+++ b/parler/models.py
@@ -65,14 +65,15 @@ from django.db import models, router
 from django.db.models.base import ModelBase
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import lazy
-from django.utils.translation import get_language, ugettext, ugettext_lazy as _
+from django.utils.translation import ugettext, ugettext_lazy as _
 from django.utils import six
 from parler import signals
 from parler.cache import MISSING, _cache_translation, _cache_translation_needs_fallback, _delete_cached_translation, get_cached_translation, _delete_cached_translations, get_cached_translated_field
 from parler.fields import TranslatedField, LanguageCodeDescriptor, TranslatedFieldDescriptor
 from parler.managers import TranslatableManager
 from parler.utils import compat
-from parler.utils.i18n import normalize_language_code, get_language_settings, get_language_title, get_null_language_error
+from parler.utils.i18n import (normalize_language_code, get_language, get_language_settings, get_language_title,
+                               get_null_language_error)
 import sys
 
 try:

--- a/parler/tests/test_utils.py
+++ b/parler/tests/test_utils.py
@@ -2,11 +2,14 @@
 
 from __future__ import unicode_literals
 
+import django
 from django.test import TestCase
+from django.utils.translation import override
 
 from parler.templatetags.parler_tags import _url_qs
+from parler.tests.utils import override_parler_settings
 from parler.utils import get_parler_languages_from_django_cms
-from parler.utils.i18n import get_language_title
+from parler.utils.i18n import get_language, get_language_title
 
 
 class UtilTestCase(TestCase):
@@ -93,6 +96,23 @@ class UtilTestCase(TestCase):
         except KeyError:
             self.fail(
                 "get_language_title() raises KeyError for missing language")
+
+    @override_parler_settings(PARLER_DEFAULT_ACTIVATE=False)
+    def test_get_language_no_fallback(self):
+        """Test get_language patch function, no fallback"""
+
+        with override(None):
+            if django.VERSION >= (1, 8):
+                self.assertEquals(get_language(), None)
+
+    @override_parler_settings(PARLER_DEFAULT_ACTIVATE=True)
+    def test_get_language_with_fallback(self):
+        """Test get_language patch function, with fallback"""
+        from parler import appsettings
+
+        with override(None):
+            if django.VERSION >= (1, 8):
+                self.assertEquals(get_language(), appsettings.PARLER_DEFAULT_LANGUAGE_CODE)
 
     def test_url_qs(self):
         matches = [

--- a/parler/utils/i18n.py
+++ b/parler/utils/i18n.py
@@ -3,7 +3,8 @@ Utils for translations
 """
 from django.conf import settings
 from django.conf.global_settings import LANGUAGES as ALL_LANGUAGES
-from django.utils.translation import ugettext_lazy as _, get_language
+from django.utils.translation import ugettext_lazy as _, get_language as dj_get_language
+
 
 __all__ = (
     'normalize_language_code',
@@ -108,3 +109,17 @@ def get_null_language_error():
         return "language_code can't be null, use translation.activate(..) when accessing translated models outside the request/response loop."
     else:
         return "language_code can't be null"
+
+
+def get_language():
+    """
+    Wrapper around Django's `get_language` utility.
+    For Django >= 1.8, `get_language` returns None in case no translation is activate.
+    Here we patch this behavior e.g. for back-end functionality requiring access to translated fields
+    """
+    from parler.appsettings import PARLER_DEFAULT_LANGUAGE_CODE, PARLER_DEFAULT_ACTIVATE
+    language = dj_get_language()
+    if language is None and PARLER_DEFAULT_ACTIVATE:
+        return PARLER_DEFAULT_LANGUAGE_CODE
+    else:
+        return language


### PR DESCRIPTION
Fixes #90 

From Django >= 1.8, Django's `get_language` behavior returns `None` in case no translation is active.
This switch allows for the old behavior, such that a default fall-back can be made available, e.g. for back-end functionality.
