### PR TITLE
WiP: This provide a more robust language validation in forms

### DIFF
--- a/parler/forms.py
+++ b/parler/forms.py
@@ -76,7 +76,14 @@ class BaseTranslatableModelForm(forms.BaseModelForm):
             else:
                 self.language_code = current_language or get_language()
 
-        if self.language_code not in dict(settings.LANGUAGES):
+        try:
+            try:
+                from django.utils.translation.trans_real import get_supported_language_variant
+                get_supported_language_variant(self.language_code)
+            except ImportError:
+                if self.language_code.split('-')[0] not in [lang[0].split('-')[0] for lang in settings.LANGUAGES]:
+                    raise LookupError('%s not supported' % self.language_code)
+        except LookupError:
             # Instead of raising a ValidationError
             raise ValueError(
                 "Translatable forms can't be initialized for the language '{0}', "

--- a/parler/tests/test_forms.py
+++ b/parler/tests/test_forms.py
@@ -43,6 +43,16 @@ class FormTests(AppTestCase):
     Test model construction
     """
 
+    def test_form_language_validation(self):
+        form_instance = SimpleForm(_current_language='fr-FR')
+        self.assertEqual(form_instance.language_code, 'fr-FR')
+
+        with self.assertRaises(ValueError):
+            SimpleForm(_current_language='fa')
+
+        with self.assertRaises(ValueError):
+            SimpleForm(_current_language='va_VN')
+
     def test_form_fields(self):
         """
         Check if the form fields exist.

--- a/runtests.py
+++ b/runtests.py
@@ -90,6 +90,12 @@ if not settings.configured:
 
         SITE_ID = 4,
         LANGUAGE_CODE = 'en',
+        LANGUAGES = (
+            ('nl', 'Dutch'),
+            ('de', 'German'),
+            ('en', 'English'),
+            ('fr', 'French'),
+        ),
         PARLER_LANGUAGES = {
             4: (
                 {'code': 'nl'},


### PR DESCRIPTION
Fix #156 

Though, it uses ``django.utils.translation.trans_real.get_supported_language_variant `` which it's not part of the official public API (see https://code.djangoproject.com/ticket/27449).
The Django 1.5 solution is uglier, but we can eventually fallback to it
