### PR TITLE
Close #195: properly check cached object before returning

### DIFF
--- a/parler/models.py
+++ b/parler/models.py
@@ -475,7 +475,7 @@ class TranslatableModelMixin(object):
             object = local_cache[language_code]
 
             # If cached object indicates the language doesn't exist, need to query the fallback.
-            if object is not MISSING:
+            if object:
                 return object
         except KeyError:
             # 2. No cache, need to query


### PR DESCRIPTION
This fixes my issue. I've got it deployed into production and it's working.

The Python `is` operator checks if two items are identical, that is, if they point to the same internal object. In this case it is possible for `object` and `MISSING` to be different instances of `parler.cache.IsMissing`. In that case the object is returned when it should not be returned.