### PR TITLE
Fixed get_or_create() call

### DIFF
--- a/parler/managers.py
+++ b/parler/managers.py
@@ -49,6 +49,20 @@ class TranslatableQuerySet(QuerySet):
             for obj in self._result_cache:
                 obj.set_current_language(self._language)
 
+    def _extract_model_params(self, defaults, **kwargs):
+        # Django>1.10 don't allow non-field attributes, so process them manually
+        translated_defaults = {}
+        for field in self.model._parler_meta.get_all_fields():
+            try:
+                translated_defaults[field] = defaults.pop(field)
+            except KeyError:
+                pass
+
+        lookup, params = super(TranslatableQuerySet, self)._extract_model_params(defaults, **kwargs)
+        params.update(translated_defaults)
+
+        return lookup, params
+
     def language(self, language_code=None):
         """
         Set the language code to assign to objects retrieved using this QuerySet.

--- a/parler/managers.py
+++ b/parler/managers.py
@@ -50,7 +50,8 @@ class TranslatableQuerySet(QuerySet):
                 obj.set_current_language(self._language)
 
     def _extract_model_params(self, defaults, **kwargs):
-        # Django>1.10 don't allow non-field attributes, so process them manually
+        # default implementation in Django>=1.11 doesn't allow non-field attributes,
+        # so process them manually
         translated_defaults = {}
         for field in self.model._parler_meta.get_all_fields():
             try:
@@ -60,6 +61,10 @@ class TranslatableQuerySet(QuerySet):
 
         lookup, params = super(TranslatableQuerySet, self)._extract_model_params(defaults, **kwargs)
         params.update(translated_defaults)
+
+        if (1, 7) <= django.VERSION < (1, 8):
+            if self._language:
+                params['_current_language'] = self._language
 
         return lookup, params
 

--- a/parler/tests/test_model_attributes.py
+++ b/parler/tests/test_model_attributes.py
@@ -303,3 +303,9 @@ class ModelAttributeTests(AppTestCase):
         # Check that we get language code as a fallback, when language is
         # not configured.
         self.assertEqual(translation_as_str, missing_language_code)
+
+    def test_get_or_create_defaults(self):
+        y, _ = SimpleModel.objects.language('nl').get_or_create(
+            shared='XXX', defaults={'tr_title': 'TRANS_TITLE'})
+        self.assertEqual(y.get_current_language(), 'nl')
+        self.assertEqual(y.tr_title, "TRANS_TITLE")


### PR DESCRIPTION
Fixes #189 

Django 1.11 introduced additional checks for the fields passed to `get_or_create` call. So we need to process translated fields manually, just like in `TranslatableModel.__init__`.

Also call to `language()` followed by `get_or_create` didn't set language correctly on newly created object in Django 1.7