### PR TITLE
Preserve language tab in the admin form

### DIFF
--- a/parler/admin.py
+++ b/parler/admin.py
@@ -390,9 +390,11 @@ class TranslatableAdmin(BaseTranslatableAdmin, admin.ModelAdmin):
         language = request.GET.get(self.query_language_key)
         if language:
             continue_urls = (uri, "../add/", reverse('admin:{0}_{1}_add'.format(*info)))
-            if redirect['Location'] in continue_urls and self.query_language_key in request.GET:
+            redirect_parts = redirect['Location'].split('?')
+            if redirect_parts[0] in continue_urls and self.query_language_key in request.GET:
                 # "Save and add another" / "Save and continue" URLs
-                redirect['Location'] += "?{0}={1}".format(self.query_language_key, language)
+                delimiter = '&' if len(redirect_parts) > 1 else '?'
+                redirect['Location'] += "{0}{1}={2}".format(delimiter, self.query_language_key, language)
         return redirect
 
     @csrf_protect_m


### PR DESCRIPTION
If you have list filter applied, having "?_changelist_filters=..." in the admin form url, then upon saving selected language tab will not be preserved. That comes from the fact that the method `_patch_redirect()` doesn't expect there to be any query parameters in redirect url.