### PR TITLE
Fix for UUID primary key models

### DIFF
--- a/parler/models.py
+++ b/parler/models.py
@@ -515,7 +515,7 @@ class TranslatableModelMixin(object):
             kwargs = {
                 'language_code': language_code,
             }
-            if self.pk:
+            if self.pk and not self._state.adding:
                 # ID might be None at this point, and Django does not allow that.
                 kwargs['master'] = self
 

--- a/parler/tests/testapp/models.py
+++ b/parler/tests/testapp/models.py
@@ -1,4 +1,6 @@
 from __future__ import unicode_literals
+import uuid
+
 from django.db import models
 from django.urls import reverse
 from django.utils.encoding import python_2_unicode_compatible
@@ -225,3 +227,24 @@ class TranslationRelatedTranslation(TranslatedFieldsModel):
 class TranslationRelatedRelation(models.Model):
     translation = models.ForeignKey(TranslationRelatedTranslation, related_name='translation_relations', on_delete=models.CASCADE)
     name = models.CharField(max_length=200)
+
+
+class IntegerPrimaryKeyModel(TranslatableModel):
+
+    translations = TranslatedFields(
+        tr_title = models.CharField("Translated Title", max_length=200)
+    )
+
+class IntegerPrimaryKeyRelatedModel(models.Model):
+    parent = models.ForeignKey('IntegerPrimaryKeyModel', on_delete=models.CASCADE, related_name='children')
+
+
+class UUIDPrimaryKeyModel(TranslatableModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    translations = TranslatedFields(
+        tr_title = models.CharField("Translated Title", max_length=200)
+    )
+
+class UUIDPrimaryKeyRelatedModel(models.Model):
+    parent = models.ForeignKey('UUIDPrimaryKeyModel', on_delete=models.CASCADE, related_name='children')


### PR DESCRIPTION
Models with a UUID primary key will have their primary key set on instantiation, rather than on save as with standard `AutoField` models. However, we cannot guarantee that it will not change before it is saved. When passing an unsaved instance to an inline formset, its primary key [can be reset](https://github.com/django/django/blob/d093e01ec05f661063507503fdf294eb6ee54dee/django/forms/models.py#L972) back to None. This doesn't play well with Parler, which will use the initial pk in its `local_cache`, and then be unable to resolve it later:

https://github.com/django-parler/django-parler/blob/11ae4af5e8faddb74c69c848870122df4006a54e/parler/models.py#L518-L523

The fix, I think, is to only store the primary key in the cache if the model has already been saved.

I've added a test case which reproduces this issue, and roughly mimics the behaviour of the admin `add_view`: 

https://github.com/django/django/blob/d093e01ec05f661063507503fdf294eb6ee54dee/django/contrib/admin/options.py#L1555-L1565

With the sqlite backend used by the test suite, no exception is raised, so I'm just asserting that the number of associated translations is correct. However with postgres, and I assume others, and `IntegrityError` will be raised by the final save.