### PR TITLE
Model.objects.create does not work in django-2.2

### DIFF
--- a/parler/managers.py
+++ b/parler/managers.py
@@ -1,6 +1,7 @@
 """
 Custom generic managers
 """
+import django
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.query import QuerySet

--- a/parler/managers.py
+++ b/parler/managers.py
@@ -54,9 +54,14 @@ class TranslatableQuerySet(QuerySet):
                 except KeyError:
                     pass
 
-        lookup, params = super(TranslatableQuerySet, self)._extract_model_params(defaults, **kwargs)
-        params.update(translated_defaults)
-        return lookup, params
+        if django.VERSION < (2, 2):
+            lookup, params = super(TranslatableQuerySet, self)._extract_model_params(defaults, **kwargs)
+            params.update(translated_defaults)
+            return lookup, params
+        else:
+            params = super(TranslatableQuerySet, self)._extract_model_params(defaults, **kwargs)
+            params.update(translated_defaults)
+            return params
 
     def language(self, language_code=None):
         """


### PR DESCRIPTION
Django 2.2 has chaged return value of methd _extract_model_params. In previous version this method returned (lookup, params) tuple. In new version returns only params.