### PR TITLE
Return full ValidationError from validate_unique

### DIFF
--- a/parler/models.py
+++ b/parler/models.py
@@ -660,7 +660,7 @@ class TranslatableModelMixin(object):
         try:
             super(TranslatableModelMixin, self).validate_unique(exclude=exclude)
         except ValidationError as e:
-            errors = e.message_dict
+            errors = e.error_dict
 
         for local_cache in six.itervalues(self._translations_cache):
             for translation in six.itervalues(local_cache):
@@ -670,7 +670,7 @@ class TranslatableModelMixin(object):
                 try:
                     translation.validate_unique(exclude=exclude)
                 except ValidationError as e:
-                    errors.update(e.message_dict)
+                    errors.update(e.error_dict)
 
         if errors:
             raise ValidationError(errors)


### PR DESCRIPTION
Method validate_unique returns only error message. It should return complete ValidationError object with all attributes (error code, params etc.)