### PR TITLE
Changed _extract_model_params to accommodate Django 2.2

### DIFF
--- a/parler/managers.py
+++ b/parler/managers.py
@@ -1,6 +1,7 @@
 """
 Custom generic managers
 """
+import django
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.query import QuerySet
@@ -54,9 +55,14 @@ class TranslatableQuerySet(QuerySet):
                 except KeyError:
                     pass
 
-        lookup, params = super(TranslatableQuerySet, self)._extract_model_params(defaults, **kwargs)
-        params.update(translated_defaults)
-        return lookup, params
+        if django.VERSION >= (2, 2):
+            params = super(TranslatableQuerySet, self)._extract_model_params(defaults, **kwargs)
+            params.update(translated_defaults)
+            return params
+        else:
+            lookup, params = super(TranslatableQuerySet, self)._extract_model_params(defaults, **kwargs)
+            params.update(translated_defaults)
+            return lookup, params
 
     def language(self, language_code=None):
         """


### PR DESCRIPTION
_extract_model_params was refactored in https://github.com/django/django/commit/6ae7aaa7d6eb880043c4c80009b36e2287bfcb92 and now only returns `params`, instead of `lookup, params`.

This commit allows both ways by checking for the Django version first.
