### PR TITLE
Using value_from_object for initial form data instead of get_prep_value

### DIFF
--- a/parler/forms.py
+++ b/parler/forms.py
@@ -62,9 +62,8 @@ class BaseTranslatableModelForm(forms.BaseModelForm):
                 else:
                     for field in meta.get_translated_fields():
                         try:
-                            value = getattr(translation, field)
-                            prepared_value = translation._meta.get_field(field).get_prep_value(value)
-                            self.initial.setdefault(field, prepared_value)
+                            model_field = translation._meta.get_field(field)
+                            self.initial.setdefault(field, model_field.value_from_object(translation))
                         except ObjectDoesNotExist:
                             # This occurs when a ForeignKey field is part of the translation,
                             # but it's value is still not yet, and the field has null=False.


### PR DESCRIPTION
Parler calls get_prep_value to fill form initial data. This method is intended to format data for database. Correct method is value_from_object. This causes problems in fields that require initial data with a particular type, e.g. filefield.

This commit does not break #226 

[issue.zip](https://github.com/django-parler/django-parler/files/3443221/issue.zip)
![issue](https://user-images.githubusercontent.com/33599/62064400-12c9d380-b22d-11e9-8c3c-3f3c5b25a825.png)
