### PR TITLE
use external six (django 3.0 compatibility)

### DIFF
--- a/docs/advanced/mptt.rst
+++ b/docs/advanced/mptt.rst
@@ -22,10 +22,11 @@ Say we have a base ``Category`` model that needs to be translatable:
 .. code-block:: python
 
     from django.db import models
-    from django.utils.encoding import python_2_unicode_compatible, force_text
+    from django.utils.encoding import force_text
     from parler.models import TranslatableModel, TranslatedFields
     from parler.managers import TranslatableManager
     from mptt.models import MPTTModel
+    from six import python_2_unicode_compatible
     from .managers import CategoryManager
 
 

--- a/docs/advanced/polymorphicmodel.rst
+++ b/docs/advanced/polymorphicmodel.rst
@@ -19,10 +19,11 @@ pattern works for a polymorphic Django model:
 .. code-block:: python
 
 	from django.db import models
-	from django.utils.encoding import python_2_unicode_compatible, force_text
+	from django.utils.encoding import force_text
 	from parler.models import TranslatableModel, TranslatedFields
 	from parler.managers import TranslatableManager
 	from polymorphic import PolymorphicModel
+	from six import python_2_unicode_compatible
 	from .managers import BookManager
 	
 

--- a/example/article/models.py
+++ b/example/article/models.py
@@ -1,9 +1,9 @@
 from __future__ import unicode_literals
 from django.db import models
 from django.urls import reverse
-from django.utils.encoding import python_2_unicode_compatible
 from parler.models import TranslatableModel, TranslatedFields
 from parler.utils.context import switch_language
+from six import python_2_unicode_compatible
 
 
 @python_2_unicode_compatible

--- a/parler/cache.py
+++ b/parler/cache.py
@@ -5,8 +5,8 @@ These functions are used internally by django-parler to fetch model data.
 Since all calls to the translation table are routed through our model descriptor fields,
 cache access and expiry is rather simple to implement.
 """
+import six
 from django.core.cache import cache
-from django.utils import six
 from parler import appsettings
 from parler.utils import get_language_settings
 

--- a/parler/forms.py
+++ b/parler/forms.py
@@ -1,10 +1,10 @@
+import six
 from django import forms
 from django.core.exceptions import NON_FIELD_ERRORS, ObjectDoesNotExist, ValidationError
 from django.forms.forms import BoundField
 from django.forms.models import ModelFormMetaclass, BaseInlineFormSet
 from django.utils.functional import cached_property
 from django.utils.translation import get_language
-from django.utils import six
 from django.utils.translation.trans_real import get_supported_language_variant
 
 from parler.models import TranslationDoesNotExist

--- a/parler/managers.py
+++ b/parler/managers.py
@@ -2,11 +2,11 @@
 Custom generic managers
 """
 import django
+import six
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.query import QuerySet
 from django.utils.translation import get_language
-from django.utils import six
 from parler import appsettings
 from parler.utils import get_active_language_choices
 

--- a/parler/models.py
+++ b/parler/models.py
@@ -6,8 +6,8 @@ The default is to use the :class:`TranslatedFields` class in the model, like:
 .. code-block:: python
 
     from django.db import models
-    from django.utils.encoding import python_2_unicode_compatible
     from parler.models import TranslatableModel, TranslatedFields
+    from six import python_2_unicode_compatible
 
 
     @python_2_unicode_compatible
@@ -28,9 +28,9 @@ It's also possible to create the translated fields model manually:
 .. code-block:: python
 
     from django.db import models
-    from django.utils.encoding import python_2_unicode_compatible
     from parler.models import TranslatableModel, TranslatedFieldsModel
     from parler.fields import TranslatedField
+    from six import python_2_unicode_compatible
 
 
     class MyModel(TranslatableModel):
@@ -63,10 +63,9 @@ from django.core.exceptions import ImproperlyConfigured, ValidationError, FieldE
 from django.db import models, router
 from django.db.models.base import ModelBase
 from django.db.models.fields.related_descriptors import ForwardManyToOneDescriptor
-from django.utils.encoding import force_text, python_2_unicode_compatible
+from django.utils.encoding import force_text
 from django.utils.functional import lazy
 from django.utils.translation import ugettext, ugettext_lazy as _
-from django.utils import six
 from parler import signals
 from parler.cache import MISSING, _cache_translation, _cache_translation_needs_fallback, _delete_cached_translation, get_cached_translation, _delete_cached_translations, get_cached_translated_field, is_missing
 from parler.fields import TranslatedField, LanguageCodeDescriptor, TranslatedFieldDescriptor, TranslationsForeignKey, _validate_master
@@ -74,6 +73,8 @@ from parler.managers import TranslatableManager
 from parler.utils import compat
 from parler.utils.i18n import (normalize_language_code, get_language, get_language_settings, get_language_title,
                                get_null_language_error)
+from six import python_2_unicode_compatible
+import six
 import sys
 import warnings
 

--- a/parler/templatetags/parler_tags.py
+++ b/parler/templatetags/parler_tags.py
@@ -1,9 +1,9 @@
 import inspect
+import six
 from django.template import Node, Library, TemplateSyntaxError
 from django.urls import reverse
 from django.utils.encoding import force_text
 from django.utils.translation import get_language
-from django.utils import six
 from parler.models import TranslatableModel, TranslationDoesNotExist
 from parler.utils.context import switch_language, smart_override
 

--- a/parler/tests/test_model_construction.py
+++ b/parler/tests/test_model_construction.py
@@ -1,9 +1,9 @@
 from functools import wraps
 import unittest
 
+import six
 from django.db import models
 from django.db.models import Manager
-from django.utils import six
 from parler.models import TranslatableModel
 from parler.models import TranslatedFields
 from .utils import AppTestCase

--- a/parler/tests/testapp/models.py
+++ b/parler/tests/testapp/models.py
@@ -3,10 +3,10 @@ import uuid
 
 from django.db import models
 from django.urls import reverse
-from django.utils.encoding import python_2_unicode_compatible
 from parler.fields import TranslatedField, TranslationsForeignKey
 from parler.models import TranslatableModel, TranslatedFields, TranslatedFieldsModel
 from parler.utils.context import switch_language
+from six import python_2_unicode_compatible
 
 
 class ManualModel(TranslatableModel):

--- a/parler/utils/conf.py
+++ b/parler/utils/conf.py
@@ -5,9 +5,9 @@ The configuration wrappers that are used for :ref:`PARLER_LANGUAGES`.
 import copy
 import sys
 
+import six
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 from django.utils.translation import get_language
 from parler.utils.i18n import is_supported_django_language, get_null_language_error
 

--- a/parler/utils/template.py
+++ b/parler/utils/template.py
@@ -1,6 +1,6 @@
+import six
 from django.template import TemplateDoesNotExist
 from django.template.loader import get_template
-from django.utils import six
 
 _cached_name_lookups = {}
 

--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,9 @@ setup(
     version=find_version('parler', '__init__.py'),
     license='Apache 2.0',
 
+    install_requires=['six'],
     requires=[
         'Django (>=1.7)',
-        'six',
     ],
 
     description='Simple Django model translations without nasty hacks, featuring nice admin integration.',

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
 
     requires=[
         'Django (>=1.7)',
+        'six',
     ],
 
     description='Simple Django model translations without nasty hacks, featuring nice admin integration.',


### PR DESCRIPTION
`django.utils.six` and `django.utils.encoding.python_2_unicode_compatible` are removed in django 3:

https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis