### PR TITLE
Added PARLER_CACHE_PREFIX for sites that share the same cache.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changes in 2.0.1 (2020-01-02)
 * Fixed using ``value_from_object()`` instead of ``get_prep_value()`` in model forms initial data.
 * Fixed using proper ``get_language()`` call when ``PARLER_DEFAULT_ACTIVATE`` is used.
 * Fixed confusing ``AttributeError`` on ``_parler_meta`` when migrations don't inherit from ``TranslatableModel``.
+* Added PARLER_CACHE_PREFIX for sites that share the same cache.
 
 
 Changes in 2.0 (2019-07-26)

--- a/docs/advanced/caching.rst
+++ b/docs/advanced/caching.rst
@@ -3,3 +3,11 @@ Disabling caching
 
 If desired, caching of translated fields can be disabled
 by adding :ref:`PARLER_ENABLE_CACHING = False <PARLER_ENABLE_CACHING>` to the settings.
+
+
+Parler on more sites with same cache
+------------------------------------
+
+If Parler runs on multiple sites that share the same cache, it is necessary
+to set a different prefix for each site
+by adding :ref:`PARLER_CACHE_PREFIX = 'mysite' <PARLER_CACHE_PREFIX>` to the settings.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -113,6 +113,18 @@ PARLER_ENABLE_CACHING
 
 This setting is strictly for experts or for troubleshooting situations, where disabling caching can be beneficial.
 
+.. _PARLER_CACHE_PREFIX:
+
+PARLER_CACHE_PREFIX
+-------------------
+
+::
+
+    PARLER_CACHE_PREFIX = ''
+
+Prefix for sites that share the same cache. For example Aldryn News & Blog.
+
+
 .. _PARLER_SHOW_EXCLUDED_LANGUAGE_TABS:
 
 PARLER_SHOW_EXCLUDED_LANGUAGE_TABS

--- a/parler/appsettings.py
+++ b/parler/appsettings.py
@@ -22,6 +22,9 @@ if not PARLER_LANGUAGES:
 
 PARLER_ENABLE_CACHING = getattr(settings, 'PARLER_ENABLE_CACHING', True)
 
+# Prefix for sites that share the same cache. For example Aldryn News & Blog.
+PARLER_CACHE_PREFIX = getattr(settings, 'PARLER_CACHE_PREFIX', '')
+
 # Have to fill the default section explicitly to avoid circular imports
 PARLER_LANGUAGES.setdefault('default', {})
 PARLER_LANGUAGES['default'].setdefault('code', PARLER_DEFAULT_LANGUAGE_CODE)

--- a/parler/cache.py
+++ b/parler/cache.py
@@ -61,7 +61,13 @@ def get_translation_cache_key(translated_model, master_id, language_code):
     """
     # Always cache the entire object, as this already produces
     # a lot of queries. Don't go for caching individual fields.
-    return 'parler.{0}.{1}.{2}.{3}'.format(translated_model._meta.app_label, translated_model.__name__, master_id, language_code)
+    return '{}parler.{}.{}.{}.{}'.format(
+        "{}.".format(appsettings.PARLER_CACHE_PREFIX) if appsettings.PARLER_CACHE_PREFIX else "",
+        translated_model._meta.app_label,
+        translated_model.__name__,
+        master_id,
+        language_code
+    )
 
 
 def get_cached_translation(instance, language_code=None, related_name=None, use_fallback=False):


### PR DESCRIPTION
If Parler runs on multiple sites that share the same cache, it is necessary to set a different prefix for each site. The conflict with shared values was found in Aldryn News & Blog - https://aldryn-newsblog.readthedocs.io/.