### PR TITLE
Fix enable to override labels, error_messages, help_texts

### DIFF
--- a/parler/forms.py
+++ b/parler/forms.py
@@ -256,6 +256,9 @@ class TranslatableModelFormMetaclass(ModelFormMetaclass):
                     fields = getattr(form_new_meta, 'fields', form_meta.fields)
                     exclude = getattr(form_new_meta, 'exclude', form_meta.exclude) or ()
                     widgets = getattr(form_new_meta, 'widgets', form_meta.widgets) or ()
+                    labels = getattr(form_new_meta, 'labels', form_meta.labels) or ()
+                    help_texts = getattr(form_new_meta, 'help_texts', form_meta.help_texts) or ()
+                    error_messages = getattr(form_new_meta, 'error_messages', form_meta.error_messages) or ()
                     formfield_callback = attrs.get('formfield_callback', None)
 
                     if fields == '__all__':
@@ -279,6 +282,15 @@ class TranslatableModelFormMetaclass(ModelFormMetaclass):
                                 kwargs = {'widget': widgets[f_name]}
                             else:
                                 kwargs = {}
+
+                            if f_name in help_texts:
+                                kwargs['help_text'] = help_texts[f_name]
+
+                            if f_name in labels:
+                                kwargs['label'] = labels[f_name]
+
+                            if f_name in error_messages:
+                                kwargs['error_messages'] = error_messages[f_name]
 
                             # See if this formfield was previously defined using a TranslatedField placeholder.
                             placeholder = _get_mro_attribute(bases, f_name)

--- a/parler/tests/test_forms.py
+++ b/parler/tests/test_forms.py
@@ -50,6 +50,25 @@ class UUIDPrimaryKeyForm(TranslatableModelForm):
         fields = '__all__'
 
 
+class OverrideMetaFieldForm(TranslatableModelForm):
+
+    class Meta:
+        model = SimpleModel
+        fields = '__all__'
+        help_texts = {
+            'shared': 'help_text:shared',
+            'tr_title': 'help_text:tr_title',
+        }
+        labels = {
+            'shared': 'label:shared',
+            'tr_title': 'label:tr_title',
+        }
+        error_messages = {
+            'shared': { 'max_length': 'error_message:shared' },
+            'tr_title': { 'max_length': 'error_message:tr_title' },
+        }
+
+
 class FormTests(AppTestCase):
     """
     Test model construction
@@ -165,6 +184,24 @@ class FormTests(AppTestCase):
         form = ForeignKeyTranslationModelForm(instance=a)
 
         self.assertTrue(True)
+
+    def test_override_meta_fields(self):
+        form_instance = OverrideMetaFieldForm(_current_language='fr-FR')
+        self.assertEqual('help_text:shared', form_instance['shared'].help_text)
+        self.assertEqual('help_text:tr_title', form_instance['tr_title'].help_text)
+        self.assertEqual('label:shared', form_instance['shared'].label)
+        self.assertEqual('label:tr_title', form_instance['tr_title'].label)
+
+        # Override error messsages
+        form_instance = OverrideMetaFieldForm(
+            _current_language='fr-FR',
+            data={
+                'shared': 'a' * 201,
+                'tr_title': 'b' * 201,
+            },
+        )
+        self.assertEqual('error_message:shared', form_instance['shared'].errors[0])
+        self.assertEqual('error_message:tr_title', form_instance['tr_title'].errors[0])
 
 
 class InlineFormTests(AppTestCase):


### PR DESCRIPTION
This PR solves overriding the default feilds problem.
close #253 

Hi, 
Currenlty django-parler can't override meta fields such as `labels`, `error_messages` and `help_texts`.

As a Django document says

>Similarly, you can specify the labels, help_texts and error_messages attributes of the inner Meta class if you want to further customize a field.

https://docs.djangoproject.com/en/3.0/topics/forms/modelforms/#overriding-the-default-fields

Of course we can define like following.

```python
class SimpleForm(TranslatableModelForm):
    tr_title = forms.CharField(labels=('...'), help_text=('...'))

    class Meta:
        model = SimpleModel
        fields = '__all__'
        labels = {
            shared: 'spam',
         }
```
but I think django-parler can override the default fields.

Could you review this and please include this 🙏 