### PR TITLE
Update url syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,16 @@
 sudo: false
 language: python
 cache: pip
-# xenial is needed for 3.7
-dist: xenial
 python:
-- '2.7'
 - '3.6'
 - '3.7'
+- '3.8'
 env:
-- DJANGO="1.11.*"
 - DJANGO="2.0.*"
 - DJANGO="2.1.*"
 - DJANGO="2.2.*"
 - DJANGO="3.0.*"
-matrix:
-  exclude:
-  # Django 1.11 is the last one supporting 2.7
-  - python: '2.7'
-    env: DJANGO="2.0.*"
-  - python: '2.7'
-    env: DJANGO="2.1.*"
-  - python: '2.7'
-    env: DJANGO="2.2.*"
-  - python: '2.7'
-    env: DJANGO="3.0.*"
+- DJANGO="3.1.*"
 before_install:
 - pip install codecov
 install:

--- a/example/article/urls.py
+++ b/example/article/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.urls import path
 from .views import ArticleListView, ArticleDetailView
 
 urlpatterns = [
-    url(r'^$', ArticleListView.as_view(), name='article-list'),
-    url(r'^(?P<slug>[^/]+)/$', ArticleDetailView.as_view(), name='article-details'),
+    path('', ArticleListView.as_view(), name='article-list'),
+    path('<slug>/', ArticleDetailView.as_view(), name='article-details'),
 ]

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 
@@ -8,6 +8,6 @@ admin.autodiscover()
 # This is not mandatory, can also use a `django_language` cookie,
 # or custom middleware that calls `django.utils.translation.activate()`.
 urlpatterns = i18n_patterns(
-    url(r'^admin/', admin.site.urls),
-    url(r'', include('article.urls')),
+    path('admin/', admin.site.urls),
+    path('', include('article.urls')),
 )

--- a/parler/admin.py
+++ b/parler/admin.py
@@ -39,7 +39,6 @@ See the :ref:`admin compatibility page <admin-compat>` for details.
 from __future__ import unicode_literals
 import django
 from django.conf import settings
-from django.conf.urls import url
 from django.contrib import admin
 from django.contrib.admin.options import csrf_protect_m, BaseModelAdmin, InlineModelAdmin
 from django.contrib.admin.utils import get_deleted_objects, quote, unquote
@@ -49,7 +48,7 @@ from django.db import router, transaction
 from django.forms import Media
 from django.http import HttpResponseRedirect, Http404, HttpRequest
 from django.shortcuts import render
-from django.urls import reverse
+from django.urls import re_path, reverse
 from django.utils.encoding import iri_to_uri, force_text
 from django.utils.functional import cached_property
 from django.utils.html import conditional_escape, escape
@@ -312,7 +311,7 @@ class TranslatableAdmin(BaseTranslatableAdmin, admin.ModelAdmin):
         else:
             opts = self.model._meta
             info = opts.app_label, opts.model_name
-            return [url(
+            return [re_path(
                 r'^(.+)/change/delete-translation/(.+)/$',
                 self.admin_site.admin_view(self.delete_translation),
                 name='{0}_{1}_delete_translation'.format(*info)

--- a/parler/cache.py
+++ b/parler/cache.py
@@ -17,11 +17,8 @@ if six.PY3:
 class IsMissing(object):
     # Allow _get_any_translated_model() to evaluate this as False.
 
-    def __nonzero__(self):
-        return False   # Python 2
-
     def __bool__(self):
-        return False   # Python 3
+        return False
 
     def __repr__(self):
         return "<IsMissing>"

--- a/parler/tests/testapp/urls.py
+++ b/parler/tests/testapp/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 from django.conf.urls.i18n import i18n_patterns
 from django.urls import reverse_lazy
 from .views import ArticleSlugView
@@ -13,17 +13,17 @@ class PasswordResetForm(auth_forms.PasswordResetForm):
 
 
 urls = [
-    url(r'article/(?P<slug>[^\/]+)/$', ArticleSlugView.as_view(), name='article-slug-test-view'),
+    path('article/<slug>/', ArticleSlugView.as_view(), name='article-slug-test-view'),
 
     # An URL with view-kwargs
-    url(
-        r'^tests/kwargs-view/$', auth_views.PasswordResetView.as_view(), {
+    path(
+        'tests/kwargs-view/', auth_views.PasswordResetView.as_view(), {
             'password_reset_form': PasswordResetForm,
             'post_reset_redirect': reverse_lazy('password-reset-done')
         },
         name='view-kwargs-test-view'
     ),
-    url(r'^password-reset/done/$', auth_views.PasswordResetDoneView.as_view(), name='password-reset-done'),
+    path('password-reset/done/', auth_views.PasswordResetDoneView.as_view(), name='password-reset-done'),
 ]
 
 urlpatterns = i18n_patterns(*urls)

--- a/parler/utils/conf.py
+++ b/parler/utils/conf.py
@@ -189,15 +189,10 @@ def get_parler_languages_from_django_cms(cms_languages=None):
     valid_keys = ['code', 'fallbacks', 'hide_untranslated',
                   'redirect_on_fallback']
     if cms_languages:
-        if sys.version_info < (3, 0, 0):
-            int_types = (int, long)
-        else:
-            int_types = int
-
         parler_languages = copy.deepcopy(cms_languages)
         for site_id, site_config in cms_languages.items():
             if site_id and (
-                    not isinstance(site_id, int_types) and
+                    not isinstance(site_id, int) and
                     site_id != 'default'
             ):
                 del parler_languages[site_id]

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
 
     install_requires=['six'],
     requires=[
-        'Django (>=1.7)',
+        'Django (>=2.0)',
     ],
 
     description='Simple Django model translations without nasty hacks, featuring nice admin integration.',
@@ -66,15 +66,15 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Application Frameworks',

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,19 @@
 [tox]
 envlist=
-    py27-django{111},
-    py36-django{111,20,21,22,30},
-    py37-django{20,21,22,30},
+    py36-django{20,21,22,30,31},
+    py37-django{20,21,22,30,31},
+    py38-django{20,21,22,30,31},
     # py33-django-dev,
     coverage,
     docs,
 
 [testenv]
 deps = django-polymorphic
-    django111: Django >= 1.11,<1.12
     django20: Django >= 2.0,<2.1
     django21: Django >= 2.1,<2.2
     django22: Django >= 2.2,<2.3
     django30: Django >= 3.0,<3.1
+    django31: Django >= 3.1,<3.2
     django-dev: https://github.com/django/django/tarball/master
 commands=
     python runtests.py


### PR DESCRIPTION
This fixes deprecation warnings in Django 3.1.

I also updated the compatibility table. I removed Django 1.11 (which is no longer supported an incompatible with the new URL syntax) and added Django 3.1.