### PR TITLE
Remove python2 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,16 @@
 sudo: false
 language: python
 cache: pip
-# xenial is needed for 3.7
-dist: xenial
 python:
-- '2.7'
 - '3.6'
 - '3.7'
+- '3.8'
 env:
-- DJANGO="1.11.*"
 - DJANGO="2.0.*"
 - DJANGO="2.1.*"
 - DJANGO="2.2.*"
 - DJANGO="3.0.*"
-matrix:
-  exclude:
-  # Django 1.11 is the last one supporting 2.7
-  - python: '2.7'
-    env: DJANGO="2.0.*"
-  - python: '2.7'
-    env: DJANGO="2.1.*"
-  - python: '2.7'
-    env: DJANGO="2.2.*"
-  - python: '2.7'
-    env: DJANGO="3.0.*"
+- DJANGO="3.1.*"
 before_install:
 - pip install codecov
 install:

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ It might be useful to limit the ``LANGUAGES`` setting. For example:
 
 .. code-block:: python
 
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
 
     LANGUAGE_CODE = 'en'
 

--- a/docs/advanced/mptt.rst
+++ b/docs/advanced/mptt.rst
@@ -26,11 +26,9 @@ Say we have a base ``Category`` model that needs to be translatable:
     from parler.models import TranslatableModel, TranslatedFields
     from parler.managers import TranslatableManager
     from mptt.models import MPTTModel
-    from six import python_2_unicode_compatible
     from .managers import CategoryManager
 
 
-    @python_2_unicode_compatible
     class Category(MPTTModel, TranslatableModel):
         # The shared base model. Either place translated fields here,
         # or place them at the subclasses (see note below).

--- a/docs/advanced/polymorphicmodel.rst
+++ b/docs/advanced/polymorphicmodel.rst
@@ -23,7 +23,6 @@ pattern works for a polymorphic Django model:
 	from parler.models import TranslatableModel, TranslatedFields
 	from parler.managers import TranslatableManager
 	from polymorphic import PolymorphicModel
-	from six import python_2_unicode_compatible
 	from .managers import BookManager
 	
 
@@ -34,7 +33,6 @@ pattern works for a polymorphic Django model:
 	    price = models.DecimalField(max_digits=10, decimal_places=2, default=0.00)
 
 
-	@python_2_unicode_compatible
 	class Book(Product, TranslatableModel):
 	    # Solution 1: use a custom manager that combines both.
 	    objects = BookManager()
@@ -48,7 +46,6 @@ pattern works for a polymorphic Django model:
 	        return force_text(self.code)
 
 
-	@python_2_unicode_compatible
 	class Pen(Product, TranslatableModel):
 	    # Solution 2: override the default manager.
 	    default_manager = TranslatableManager()

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -50,6 +50,6 @@ When you display translated objects in a form, e.g. a select list, you can prefe
 
     class MyModelAdminForm(TranslatableModelForm):
         def __init__(self, *args, **kwargs):
-            super(MyModelAdminForm, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
             self.fields['some_field'].queryset = self.fields['some_field'].queryset.prefetch_related('translations')
 

--- a/example/article/migrations/0001_initial.py
+++ b/example/article/migrations/0001_initial.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models, migrations
 
 

--- a/example/article/migrations/0001_initial.py
+++ b/example/article/migrations/0001_initial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from django.db import models, migrations
 
 

--- a/example/article/models.py
+++ b/example/article/models.py
@@ -3,10 +3,8 @@ from django.db import models
 from django.urls import reverse
 from parler.models import TranslatableModel, TranslatedFields
 from parler.utils.context import switch_language
-from six import python_2_unicode_compatible
 
 
-@python_2_unicode_compatible
 class Article(TranslatableModel):
     """
     Example translatable model.
@@ -51,7 +49,6 @@ class Article(TranslatableModel):
         return dict(self.translations.values_list('language_code', 'slug'))
 
 
-@python_2_unicode_compatible
 class Category(models.Model):
     """
     Example model for inline edition of Articles

--- a/example/article/models.py
+++ b/example/article/models.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from django.db import models
 from django.urls import reverse
 from parler.models import TranslatableModel, TranslatedFields

--- a/example/article/tests.py
+++ b/example/article/tests.py
@@ -37,10 +37,10 @@ class TestMixin(object):
         self.art_id = art.id
 
     def assertInContent(self, member, resp, msg=None):
-        return super(TestMixin, self).assertIn(member, encoding.smart_text(resp.content), msg)
+        return super().assertIn(member, encoding.smart_text(resp.content), msg)
 
     def assertNotInContent(self, member, resp, msg=None):
-        return super(TestMixin, self).assertNotIn(member, encoding.smart_text(resp.content), msg)
+        return super().assertNotIn(member, encoding.smart_text(resp.content), msg)
 
     def assertHTMLInContent(self, html_tag, resp):
         find_html = parse_html(html_tag)
@@ -109,7 +109,7 @@ class AdminArticleTestCase(TestMixin, TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(AdminArticleTestCase, cls).setUpClass()
+        super().setUpClass()
         cls.user, _ = auth.models.User.objects.get_or_create(is_superuser=True, is_staff=True, username=cls.credentials['username'])
         cls.user.set_password(cls.credentials['password'])
         cls.user.save()

--- a/example/article/tests.py
+++ b/example/article/tests.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from collections import deque
 
 import django

--- a/example/article/tests.py
+++ b/example/article/tests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from collections import deque
 
 import django

--- a/example/article/tests.py
+++ b/example/article/tests.py
@@ -13,7 +13,7 @@ from .models import Article, Category
 from parler.appsettings import PARLER_LANGUAGES
 
 
-class TestMixin(object):
+class TestMixin:
 
     def setUp(self):
         cat = Category()

--- a/example/article/urls.py
+++ b/example/article/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.urls import path
 from .views import ArticleListView, ArticleDetailView
 
 urlpatterns = [
-    url(r'^$', ArticleListView.as_view(), name='article-list'),
-    url(r'^(?P<slug>[^/]+)/$', ArticleDetailView.as_view(), name='article-details'),
+    path('', ArticleListView.as_view(), name='article-list'),
+    path('<slug>/', ArticleDetailView.as_view(), name='article-details'),
 ]

--- a/example/article/views.py
+++ b/example/article/views.py
@@ -8,7 +8,7 @@ class BaseArticleMixin(object):
     # Only show published articles.
 
     def get_queryset(self):
-        return super(BaseArticleMixin, self).get_queryset().filter(published=True)
+        return super().get_queryset().filter(published=True)
 
 
 class ArticleListView(BaseArticleMixin, ListView):
@@ -18,7 +18,7 @@ class ArticleListView(BaseArticleMixin, ListView):
     def get_queryset(self):
         # Only show objects translated in the current language.
         language = get_language()
-        return super(ArticleListView, self).get_queryset().filter(translations__language_code=language)
+        return super().get_queryset().filter(translations__language_code=language)
 
 
 class ArticleDetailView(BaseArticleMixin, TranslatableSlugMixin, DetailView):

--- a/example/article/views.py
+++ b/example/article/views.py
@@ -4,7 +4,7 @@ from .models import Article
 from parler.views import TranslatableSlugMixin
 
 
-class BaseArticleMixin(object):
+class BaseArticleMixin:
     # Only show published articles.
 
     def get_queryset(self):

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 
@@ -8,6 +8,6 @@ admin.autodiscover()
 # This is not mandatory, can also use a `django_language` cookie,
 # or custom middleware that calls `django.utils.translation.activate()`.
 urlpatterns = i18n_patterns(
-    url(r'^admin/', admin.site.urls),
-    url(r'', include('article.urls')),
+    path('admin/', admin.site.urls),
+    path('', include('article.urls')),
 )

--- a/parler/admin.py
+++ b/parler/admin.py
@@ -36,7 +36,6 @@ While almost every admin feature just works, there are a few special cases to ta
 
 See the :ref:`admin compatibility page <admin-compat>` for details.
 """
-from __future__ import unicode_literals
 import django
 from django.conf import settings
 from django.contrib import admin

--- a/parler/admin.py
+++ b/parler/admin.py
@@ -54,7 +54,7 @@ from django.utils.functional import cached_property
 from django.utils.html import conditional_escape, escape
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _, get_language
+from django.utils.translation import gettext_lazy as _, get_language
 from parler import appsettings
 from parler.forms import TranslatableModelForm, TranslatableBaseInlineFormSet
 from parler.managers import TranslatableQuerySet

--- a/parler/admin.py
+++ b/parler/admin.py
@@ -105,7 +105,7 @@ class BaseTranslatableAdmin(BaseModelAdmin):
         # TODO: as a fix TranslatedFields should become a RelatedField on the shared model (may also support ORM queries)
         # As workaround, declare the fields in get_prepopulated_fields() and we'll provide the admin media automatically.
         has_prepopulated = len(self.get_prepopulated_fields(_fakeRequest))
-        base_media = super(BaseTranslatableAdmin, self).media
+        base_media = super().media
         if has_prepopulated:
             return base_media + _language_prepopulated_media
         else:
@@ -146,7 +146,7 @@ class BaseTranslatableAdmin(BaseModelAdmin):
         """
         Make sure the current language is selected.
         """
-        qs = super(BaseTranslatableAdmin, self).get_queryset(request)
+        qs = super().get_queryset(request)
 
         if self._has_translatable_model():
             if not isinstance(qs, TranslatableQuerySet):
@@ -269,7 +269,7 @@ class TranslatableAdmin(BaseTranslatableAdmin, admin.ModelAdmin):
             return self.model._parler_meta.root_model.objects.none()
 
     def get_queryset(self, request):
-        qs = super(TranslatableAdmin, self).get_queryset(request)
+        qs = super().get_queryset(request)
 
         if self.prefetch_language_column:
             # When the available languages are shown in the listing, prefetch available languages.
@@ -284,7 +284,7 @@ class TranslatableAdmin(BaseTranslatableAdmin, admin.ModelAdmin):
         """
         Make sure the object is fetched in the correct language.
         """
-        obj = super(TranslatableAdmin, self).get_object(request, object_id, *args, **kwargs)
+        obj = super().get_object(request, object_id, *args, **kwargs)
 
         if obj is not None and self._has_translatable_model():  # Allow fallback to regular models.
             obj.set_current_language(self._language(request, obj), initialize=True)
@@ -295,7 +295,7 @@ class TranslatableAdmin(BaseTranslatableAdmin, admin.ModelAdmin):
         """
         Pass the current language to the form.
         """
-        form_class = super(TranslatableAdmin, self).get_form(request, obj, **kwargs)
+        form_class = super().get_form(request, obj, **kwargs)
         if self._has_translatable_model():
             form_class.language_code = self.get_form_language(request, obj)
 
@@ -305,7 +305,7 @@ class TranslatableAdmin(BaseTranslatableAdmin, admin.ModelAdmin):
         """
         Add a delete-translation view.
         """
-        urlpatterns = super(TranslatableAdmin, self).get_urls()
+        urlpatterns = super().get_urls()
         if not self._has_translatable_model():
             return urlpatterns
         else:
@@ -350,16 +350,16 @@ class TranslatableAdmin(BaseTranslatableAdmin, admin.ModelAdmin):
             context['default_change_form_template'] = self.default_change_form_template
 
         #context['base_template'] = self.get_change_form_base_template()
-        return super(TranslatableAdmin, self).render_change_form(request, context, add, change, form_url, obj)
+        return super().render_change_form(request, context, add, change, form_url, obj)
 
     def response_add(self, request, obj, post_url_continue=None):
         # Make sure ?language=... is included in the redirects.
-        redirect = super(TranslatableAdmin, self).response_add(request, obj, post_url_continue)
+        redirect = super().response_add(request, obj, post_url_continue)
         return self._patch_redirect(request, obj, redirect)
 
     def response_change(self, request, obj):
         # Make sure ?language=... is included in the redirects.
-        redirect = super(TranslatableAdmin, self).response_change(request, obj)
+        redirect = super().response_change(request, obj)
         return self._patch_redirect(request, obj, redirect)
 
     def _patch_redirect(self, request, obj, redirect):
@@ -614,7 +614,7 @@ class TranslatableInlineModelAdmin(BaseTranslatableAdmin, InlineModelAdmin):
         """
         Return the formset, and provide the language information to the formset.
         """
-        FormSet = super(TranslatableInlineModelAdmin, self).get_formset(request, obj, **kwargs)
+        FormSet = super().get_formset(request, obj, **kwargs)
         # Existing objects already got the language code from the queryset().language() method.
         # For new objects, the language code should be set here.
         FormSet.language_code = self.get_form_language(request, obj)
@@ -632,7 +632,7 @@ class TranslatableInlineModelAdmin(BaseTranslatableAdmin, InlineModelAdmin):
         Return the current language for the currently displayed object fields.
         """
         if self._has_translatable_parent_model():
-            return super(TranslatableInlineModelAdmin, self).get_form_language(request, obj=obj)
+            return super().get_form_language(request, obj=obj)
         else:
             # Follow the ?language parameter
             return self._language(request)
@@ -700,5 +700,5 @@ class SortedRelatedFieldListFilter(admin.RelatedFieldListFilter):
     """
 
     def __init__(self, *args, **kwargs):
-        super(SortedRelatedFieldListFilter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.lookup_choices = sorted(self.lookup_choices, key=lambda a: a[1].lower())

--- a/parler/admin.py
+++ b/parler/admin.py
@@ -39,7 +39,6 @@ See the :ref:`admin compatibility page <admin-compat>` for details.
 from __future__ import unicode_literals
 import django
 from django.conf import settings
-from django.conf.urls import url
 from django.contrib import admin
 from django.contrib.admin.options import csrf_protect_m, BaseModelAdmin, InlineModelAdmin
 from django.contrib.admin.utils import get_deleted_objects, quote, unquote
@@ -49,7 +48,7 @@ from django.db import router, transaction
 from django.forms import Media
 from django.http import HttpResponseRedirect, Http404, HttpRequest
 from django.shortcuts import render
-from django.urls import reverse
+from django.urls import re_path, reverse
 from django.utils.encoding import iri_to_uri, force_text
 from django.utils.functional import cached_property
 from django.utils.html import conditional_escape, escape
@@ -312,7 +311,7 @@ class TranslatableAdmin(BaseTranslatableAdmin, admin.ModelAdmin):
         else:
             opts = self.model._meta
             info = opts.app_label, opts.model_name
-            return [url(
+            return [re_path(
                 r'^(.+)/change/delete-translation/(.+)/$',
                 self.admin_site.admin_view(self.delete_translation),
                 name='{0}_{1}_delete_translation'.format(*info)

--- a/parler/cache.py
+++ b/parler/cache.py
@@ -10,7 +10,7 @@ from parler import appsettings
 from parler.utils import get_language_settings
 
 
-class IsMissing(object):
+class IsMissing:
     # Allow _get_any_translated_model() to evaluate this as False.
 
     def __bool__(self):

--- a/parler/cache.py
+++ b/parler/cache.py
@@ -5,13 +5,9 @@ These functions are used internally by django-parler to fetch model data.
 Since all calls to the translation table are routed through our model descriptor fields,
 cache access and expiry is rather simple to implement.
 """
-import six
 from django.core.cache import cache
 from parler import appsettings
 from parler.utils import get_language_settings
-
-if six.PY3:
-    long = int
 
 
 class IsMissing(object):

--- a/parler/cache.py
+++ b/parler/cache.py
@@ -17,11 +17,8 @@ if six.PY3:
 class IsMissing(object):
     # Allow _get_any_translated_model() to evaluate this as False.
 
-    def __nonzero__(self):
-        return False   # Python 2
-
     def __bool__(self):
-        return False   # Python 3
+        return False
 
     def __repr__(self):
         return "<IsMissing>"

--- a/parler/fields.py
+++ b/parler/fields.py
@@ -9,8 +9,6 @@ but may be added explicitly as well. This also allows to set the ``any_language`
 It's also useful for abstract models; add a :class:`TranslatedField` to
 indicate that the derived model is expected to provide that translatable field.
 """
-from __future__ import unicode_literals
-
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.fields.related_descriptors import ForwardManyToOneDescriptor

--- a/parler/fields.py
+++ b/parler/fields.py
@@ -59,7 +59,7 @@ class TranslationsForeignKey(models.ForeignKey):
 
 
 # TODO: inherit RelatedField?
-class TranslatedField(object):
+class TranslatedField:
     """
     Proxy field attached to a model.
 
@@ -109,7 +109,7 @@ class TranslatedField(object):
         return self._meta
 
 
-class TranslatedFieldDescriptor(object):
+class TranslatedFieldDescriptor:
     """
     Descriptor for translated attributes.
 
@@ -185,7 +185,7 @@ class TranslatedFieldDescriptor(object):
         return field.verbose_name
 
 
-class LanguageCodeDescriptor(object):
+class LanguageCodeDescriptor:
     """
     This is the property to access the ``language_code`` in the ``TranslatableModel``.
     """

--- a/parler/fields.py
+++ b/parler/fields.py
@@ -52,7 +52,7 @@ class TranslationsForeignKey(models.ForeignKey):
     def contribute_to_related_class(self, cls, related):
         from parler.models import TranslatedFieldsModelMixin
 
-        super(TranslationsForeignKey, self).contribute_to_related_class(cls, related)
+        super().contribute_to_related_class(cls, related)
         _validate_master(self.model)
         if issubclass(self.model, TranslatedFieldsModelMixin):
             self.model.contribute_translations(cls)
@@ -95,7 +95,7 @@ class TranslatedField(object):
         self._meta = None
 
     def contribute_to_class(self, cls, name, **kwargs):
-        #super(TranslatedField, self).contribute_to_class(cls, name)
+        #super().contribute_to_class(cls, name)
         self.model = cls
         self.name = name
 

--- a/parler/forms.py
+++ b/parler/forms.py
@@ -45,7 +45,7 @@ class BaseTranslatableModelForm(forms.BaseModelForm):
 
     def __init__(self, *args, **kwargs):
         current_language = kwargs.pop('_current_language', None)   # Used for TranslatableViewMixin
-        super(BaseTranslatableModelForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # Load the initial values for the translated fields
         instance = kwargs.get('instance', None)
@@ -123,7 +123,7 @@ class BaseTranslatableModelForm(forms.BaseModelForm):
         self.save_translated_fields()
 
         # Perform the regular clean checks, this also updates self.instance
-        super(BaseTranslatableModelForm, self)._post_clean()
+        super()._post_clean()
 
     def save_translated_fields(self):
         """
@@ -178,7 +178,7 @@ class BaseTranslatableModelForm(forms.BaseModelForm):
         Return a :class:`TranslatableBoundField` for translated models.
         This extends the default ``form[field]`` interface that produces the BoundField for HTML templates.
         """
-        boundfield = super(BaseTranslatableModelForm, self).__getitem__(name)
+        boundfield = super().__getitem__(name)
         if name in self._translated_fields:
             # Oh the wonders of Python :)
             boundfield.__class__ = _upgrade_boundfield_class(boundfield.__class__)
@@ -218,7 +218,7 @@ class TranslatableBoundField(BoundField):
             attrs = {}
 
         attrs['class'] = (attrs.get('class', '') + " translatable-field").strip()
-        return super(TranslatableBoundField, self).label_tag(contents, attrs, *args, **kwargs)
+        return super().label_tag(contents, attrs, *args, **kwargs)
 
     # The as_widget() won't be overwritten to add a 'class' attr,
     # because it will overwrite what AdminTextInputWidget and fields have as default.
@@ -302,7 +302,7 @@ class TranslatableModelFormMetaclass(ModelFormMetaclass):
                                 attrs[f_name] = formfield
 
         # Call the super class with updated `attrs` dict.
-        return super(TranslatableModelFormMetaclass, mcs).__new__(mcs, name, bases, attrs)
+        return super().__new__(mcs, name, bases, attrs)
 
 
 def _get_mro_attribute(bases, name, default=None):
@@ -355,12 +355,12 @@ class TranslatableBaseInlineFormSet(BaseInlineFormSet):
     language_code = None
 
     def _construct_form(self, i, **kwargs):
-        form = super(TranslatableBaseInlineFormSet, self)._construct_form(i, **kwargs)
+        form = super()._construct_form(i, **kwargs)
         form.language_code = self.language_code   # Pass the language code for new objects!
         return form
 
     def save_new(self, form, commit=True):
-        obj = super(TranslatableBaseInlineFormSet, self).save_new(form, commit)
+        obj = super().save_new(form, commit)
         return obj
 
 

--- a/parler/forms.py
+++ b/parler/forms.py
@@ -1,4 +1,3 @@
-import six
 from django import forms
 from django.core.exceptions import NON_FIELD_ERRORS, ObjectDoesNotExist, ValidationError
 from django.forms import BoundField
@@ -245,7 +244,7 @@ class TranslatableModelFormMetaclass(ModelFormMetaclass):
 
             # Detect all placeholders at this class level.
             placeholder_fields = [
-                f_name for f_name, attr_value in six.iteritems(attrs) if isinstance(attr_value, TranslatedField)
+                f_name for f_name, attr_value in attrs.items() if isinstance(attr_value, TranslatedField)
             ]
 
             # Include the translated fields as attributes, pretend that these exist on the form.
@@ -335,7 +334,7 @@ def _get_model_form_field(model, name, formfield_callback=None, **kwargs):
     return formfield
 
 
-class TranslatableModelForm(six.with_metaclass(TranslatableModelFormMetaclass, BaseTranslatableModelForm, forms.ModelForm)):
+class TranslatableModelForm(BaseTranslatableModelForm, forms.ModelForm, metaclass=TranslatableModelFormMetaclass):
     """
     The model form to use for translated models.
     """

--- a/parler/forms.py
+++ b/parler/forms.py
@@ -17,7 +17,7 @@ __all__ = (
 )
 
 
-class TranslatedField(object):
+class TranslatedField:
     """
     A wrapper for a translated form field.
 

--- a/parler/managers.py
+++ b/parler/managers.py
@@ -54,14 +54,9 @@ class TranslatableQuerySet(QuerySet):
                 except KeyError:
                     pass
 
-        if django.VERSION < (2, 2):
-            lookup, params = super()._extract_model_params(defaults, **kwargs)
-            params.update(translated_defaults)
-            return lookup, params
-        else:
-            params = super()._extract_model_params(defaults, **kwargs)
-            params.update(translated_defaults)
-            return params
+        params = super()._extract_model_params(defaults, **kwargs)
+        params.update(translated_defaults)
+        return params
 
     def language(self, language_code=None):
         """

--- a/parler/managers.py
+++ b/parler/managers.py
@@ -19,11 +19,11 @@ class TranslatableQuerySet(QuerySet):
     """
 
     def __init__(self, *args, **kwargs):
-        super(TranslatableQuerySet, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._language = None
 
     def _clone(self):
-        c = super(TranslatableQuerySet, self)._clone()
+        c = super()._clone()
         c._language = self._language
         return c
 
@@ -32,13 +32,13 @@ class TranslatableQuerySet(QuerySet):
         # like .language('xx').create(..) which is a nice API after all.
         if self._language:
             kwargs['_current_language'] = self._language
-        return super(TranslatableQuerySet, self).create(**kwargs)
+        return super().create(**kwargs)
 
     def _fetch_all(self):
         # Make sure the current language is assigned when Django fetches the data.
         # This low-level method is overwritten as that works better across Django versions.
         # Alternatives includes hacking the _iterable_class, which breaks django-polymorphic
-        super(TranslatableQuerySet, self)._fetch_all()
+        super()._fetch_all()
         if self._language is not None and self._result_cache and isinstance(self._result_cache[0], models.Model):
             for obj in self._result_cache:
                 obj.set_current_language(self._language)
@@ -55,11 +55,11 @@ class TranslatableQuerySet(QuerySet):
                     pass
 
         if django.VERSION < (2, 2):
-            lookup, params = super(TranslatableQuerySet, self)._extract_model_params(defaults, **kwargs)
+            lookup, params = super()._extract_model_params(defaults, **kwargs)
             params.update(translated_defaults)
             return lookup, params
         else:
-            params = super(TranslatableQuerySet, self)._extract_model_params(defaults, **kwargs)
+            params = super()._extract_model_params(defaults, **kwargs)
             params.update(translated_defaults)
             return params
 
@@ -130,7 +130,7 @@ class TranslatableManager(models.Manager.from_queryset(TranslatableQuerySet)):
     """
 
     def get_queryset(self):
-        qs = super(TranslatableManager, self).get_queryset()
+        qs = super().get_queryset()
         if not isinstance(qs, TranslatableQuerySet):
             raise ImproperlyConfigured("{0}._queryset_class does not inherit from TranslatableQuerySet".format(self.__class__.__name__))
         return qs

--- a/parler/managers.py
+++ b/parler/managers.py
@@ -2,7 +2,6 @@
 Custom generic managers
 """
 import django
-import six
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.query import QuerySet
@@ -97,7 +96,7 @@ class TranslatableQuerySet(QuerySet):
             language_codes = (get_language(),)
 
         filters = {}
-        for field_name, val in six.iteritems(translated_fields):
+        for field_name, val in translated_fields.items():
             if field_name.startswith('master__'):
                 filters[field_name[8:]] = val  # avoid translations__master__ back and forth
             else:

--- a/parler/models.py
+++ b/parler/models.py
@@ -53,7 +53,6 @@ the :func:`~django.db.models.Model.save` method, or add new methods yourself.
 The translated model is compatible with django-hvad, making the transition between both projects relatively easy.
 The manager and queryset objects of django-parler can work together with django-mptt and django-polymorphic.
 """
-from __future__ import unicode_literals
 from collections import defaultdict, OrderedDict
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, ValidationError, FieldError, ObjectDoesNotExist

--- a/parler/models.py
+++ b/parler/models.py
@@ -250,7 +250,7 @@ class TranslatableModelMixin(object):
         self._current_language = None
 
         # Run original Django model __init__
-        super(TranslatableModelMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # Assign translated args manually.
         self._translations_cache = defaultdict(dict)
@@ -635,7 +635,7 @@ class TranslatableModelMixin(object):
         return languages_seen
 
     def save(self, *args, **kwargs):
-        super(TranslatableModelMixin, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
         # Makes no sense to add these for translated model
         # Even worse: mptt 0.7 injects this parameter when it avoids updating the lft/rgt fields,
@@ -645,7 +645,7 @@ class TranslatableModelMixin(object):
 
     def delete(self, using=None):
         _delete_cached_translations(self)
-        return super(TranslatableModelMixin, self).delete(using)
+        return super().delete(using)
 
     def validate_unique(self, exclude=None):
         """
@@ -654,7 +654,7 @@ class TranslatableModelMixin(object):
         # This is called from ModelForm._post_clean() or Model.full_clean()
         errors = {}
         try:
-            super(TranslatableModelMixin, self).validate_unique(exclude=exclude)
+            super().validate_unique(exclude=exclude)
         except ValidationError as e:
             errors = e.error_dict
 
@@ -766,7 +766,7 @@ class TranslatableModelMixin(object):
             return default
 
     def refresh_from_db(self, *args, **kwargs):
-        super(TranslatableModelMixin, self).refresh_from_db(*args, **kwargs)
+        super().refresh_from_db(*args, **kwargs)
         _delete_cached_translations(self)
         self._translations_cache.clear()
     refresh_from_db.alters_data = True
@@ -799,7 +799,7 @@ class TranslatedFieldsModelBase(ModelBase):
     """
     def __new__(mcs, name, bases, attrs):
 
-        new_class = super(TranslatedFieldsModelBase, mcs).__new__(mcs, name, bases, attrs)
+        new_class = super().__new__(mcs, name, bases, attrs)
         if bases[0] == models.Model:
             return new_class
 
@@ -831,7 +831,7 @@ class TranslatedFieldsModelMixin(object):
 
     def __init__(self, *args, **kwargs):
         signals.pre_translation_init.send(sender=self.__class__, args=args, kwargs=kwargs)
-        super(TranslatedFieldsModelMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._original_values = self._get_field_values()
 
         signals.post_translation_init.send(sender=self.__class__, args=args, kwargs=kwargs)
@@ -885,7 +885,7 @@ class TranslatedFieldsModelMixin(object):
             )
 
         # Perform save
-        super(TranslatedFieldsModelMixin, self).save_base(raw=raw, using=using, **kwargs)
+        super().save_base(raw=raw, using=using, **kwargs)
         self._original_values = self._get_field_values()
         _cache_translation(self)
 
@@ -902,7 +902,7 @@ class TranslatedFieldsModelMixin(object):
         if not self._meta.auto_created:
             signals.pre_translation_delete.send(sender=self.shared_model, instance=self, using=using)
 
-        super(TranslatedFieldsModelMixin, self).delete(using=using)
+        super().delete(using=using)
         _delete_cached_translation(self)
 
         # Send post-delete signal

--- a/parler/models.py
+++ b/parler/models.py
@@ -164,7 +164,7 @@ def create_translations_model(shared_model, related_name, meta, **fields):
     return translations_model
 
 
-class TranslatedFields(object):
+class TranslatedFields:
     """
     Wrapper class to define translated fields on a model.
 
@@ -218,7 +218,7 @@ class TranslatedFields(object):
         create_translations_model(cls, name, self.meta, **self.fields)
 
 
-class TranslatableModelMixin(object):
+class TranslatableModelMixin:
     """
     Base model mixin class to handle translations.
 
@@ -822,7 +822,7 @@ class TranslatedFieldsModelBase(ModelBase):
         return new_class
 
 
-class TranslatedFieldsModelMixin(object):
+class TranslatedFieldsModelMixin:
     """
     Base class for the model that holds the translated fields.
     """
@@ -995,7 +995,7 @@ class TranslatedFieldsModel(TranslatedFieldsModelMixin, models.Model, metaclass=
         default_permissions = ()
 
 
-class ParlerMeta(object):
+class ParlerMeta:
     """
     Meta data for a single inheritance level.
     """
@@ -1022,7 +1022,7 @@ class ParlerMeta(object):
         )
 
 
-class ParlerOptions(object):
+class ParlerOptions:
     """
     Meta data for the translatable models.
     """

--- a/parler/models.py
+++ b/parler/models.py
@@ -62,7 +62,7 @@ from django.db.models.base import ModelBase
 from django.db.models.fields.related_descriptors import ForwardManyToOneDescriptor
 from django.utils.encoding import force_text
 from django.utils.functional import lazy
-from django.utils.translation import ugettext, ugettext_lazy as _
+from django.utils.translation import gettext, gettext_lazy as _
 from parler import signals
 from parler.cache import MISSING, _cache_translation, _cache_translation_needs_fallback, _delete_cached_translation, get_cached_translation, _delete_cached_translations, get_cached_translated_field, is_missing
 from parler.fields import TranslatedField, LanguageCodeDescriptor, TranslatedFieldDescriptor, TranslationsForeignKey, _validate_master
@@ -103,7 +103,7 @@ class TranslationDoesNotExist(AttributeError, ObjectDoesNotExist):
     pass
 
 
-_lazy_verbose_name = lazy(lambda x: ugettext("{0} Translation").format(x._meta.verbose_name), str)
+_lazy_verbose_name = lazy(lambda x: gettext("{0} Translation").format(x._meta.verbose_name), str)
 
 
 def create_translations_model(shared_model, related_name, meta, **fields):

--- a/parler/templatetags/parler_tags.py
+++ b/parler/templatetags/parler_tags.py
@@ -1,5 +1,4 @@
 import inspect
-import six
 from django.template import Node, Library, TemplateSyntaxError
 from django.urls import reverse
 from django.utils.encoding import force_text
@@ -188,4 +187,4 @@ def _cleanup_urlpattern_kwargs(kwargs):
     # it's not a problem because the reverse() function just ignores them as there is no match.
     # However, for class values, an exception occurs because reverse() wants to force_text() them.
     # Hence, remove the kwargs to avoid internal server errors on some exotic views.
-    return dict((k, v) for k, v in six.iteritems(kwargs) if not inspect.isclass(v))
+    return dict((k, v) for k, v in kwargs.items() if not inspect.isclass(v))

--- a/parler/tests/test_admin.py
+++ b/parler/tests/test_admin.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.contrib.admin import AdminSite
 from django.contrib.admin.utils import label_for_field
 

--- a/parler/tests/test_model_attributes.py
+++ b/parler/tests/test_model_attributes.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from django.utils import translation
 from parler.models import TranslationDoesNotExist
 from .utils import AppTestCase

--- a/parler/tests/test_model_construction.py
+++ b/parler/tests/test_model_construction.py
@@ -1,7 +1,6 @@
 from functools import wraps
 import unittest
 
-import six
 from django.db import models
 from django.db.models import Manager
 from parler.models import TranslatableModel

--- a/parler/tests/test_model_inheritance.py
+++ b/parler/tests/test_model_inheritance.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from django.core.cache import cache
 from .utils import AppTestCase
 from .testapp.models import Level2

--- a/parler/tests/test_query_count.py
+++ b/parler/tests/test_query_count.py
@@ -16,7 +16,7 @@ class QueryCountTests(AppTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(QueryCountTests, cls).setUpClass()
+        super().setUpClass()
 
         cls.country_list = (
             'Mexico',

--- a/parler/tests/test_urls.py
+++ b/parler/tests/test_urls.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from django.test import RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse, resolve, get_urlconf

--- a/parler/tests/test_urls.py
+++ b/parler/tests/test_urls.py
@@ -15,7 +15,7 @@ class UrlTests(AppTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(UrlTests, cls).setUpClass()
+        super().setUpClass()
         article = ArticleSlugModel(_current_language=cls.conf_fallback, slug='default')
         article.set_current_language(cls.other_lang1)
         article.slug = 'lang1'

--- a/parler/tests/test_utils.py
+++ b/parler/tests/test_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from django.test import TestCase
 from django.utils.translation import override
 

--- a/parler/tests/test_utils.py
+++ b/parler/tests/test_utils.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from django.test import TestCase
 from django.utils.translation import override
 

--- a/parler/tests/testapp/models.py
+++ b/parler/tests/testapp/models.py
@@ -6,7 +6,6 @@ from django.urls import reverse
 from parler.fields import TranslatedField, TranslationsForeignKey
 from parler.models import TranslatableModel, TranslatedFields, TranslatedFieldsModel
 from parler.utils.context import switch_language
-from six import python_2_unicode_compatible
 
 
 class ManualModel(TranslatableModel):
@@ -18,7 +17,6 @@ class ManualModelTranslations(TranslatedFieldsModel):
     tr_title = models.CharField(max_length=200)
 
 
-@python_2_unicode_compatible
 class SimpleModel(TranslatableModel):
     shared = models.CharField(max_length=200, default='')
 
@@ -37,7 +35,6 @@ class CleanCharField(models.CharField):
         return value + "_cleanchar"
 
 
-@python_2_unicode_compatible
 class CleanFieldModel(TranslatableModel):
     shared = CleanCharField(max_length=200, default='')
     tr_title = TranslatedField()
@@ -62,7 +59,6 @@ class CleanFieldModelTranslation(TranslatedFieldsModel):
         self.tr_title += "_cleantrans"
 
 
-@python_2_unicode_compatible
 class DateTimeModel(TranslatableModel):
     shared = models.CharField(max_length=200, default='')
     datetime = models.DateTimeField()
@@ -75,7 +71,6 @@ class DateTimeModel(TranslatableModel):
         return self.tr_title
 
 
-@python_2_unicode_compatible
 class AnyLanguageModel(TranslatableModel):
     shared = models.CharField(max_length=200, default='')
     tr_title = TranslatedField(any_language=True)
@@ -88,7 +83,6 @@ class AnyLanguageModel(TranslatableModel):
         return self.tr_title
 
 
-@python_2_unicode_compatible
 class NotRequiredModel(TranslatableModel):
     shared = models.CharField(max_length=200, default='')
 
@@ -100,7 +94,6 @@ class NotRequiredModel(TranslatableModel):
         return self.tr_title
 
 
-@python_2_unicode_compatible
 class EmptyModel(TranslatableModel):
     shared = models.CharField(max_length=200, default='')
 
@@ -112,7 +105,6 @@ class EmptyModel(TranslatableModel):
         return self.shared
 
 
-@python_2_unicode_compatible
 class ArticleSlugModel(TranslatableModel):
     translations = TranslatedFields(
         slug = models.SlugField()

--- a/parler/tests/testapp/models.py
+++ b/parler/tests/testapp/models.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import uuid
 
 from django.db import models

--- a/parler/tests/testapp/models.py
+++ b/parler/tests/testapp/models.py
@@ -31,7 +31,7 @@ class SimpleModel(TranslatableModel):
 class CleanCharField(models.CharField):
 
     def clean(self, value, model_instance):
-        super(CleanCharField, self).clean(value, model_instance)
+        super().clean(value, model_instance)
         return value + "_cleanchar"
 
 

--- a/parler/tests/testapp/urls.py
+++ b/parler/tests/testapp/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 from django.conf.urls.i18n import i18n_patterns
 from django.urls import reverse_lazy
 from .views import ArticleSlugView
@@ -13,17 +13,17 @@ class PasswordResetForm(auth_forms.PasswordResetForm):
 
 
 urls = [
-    url(r'article/(?P<slug>[^\/]+)/$', ArticleSlugView.as_view(), name='article-slug-test-view'),
+    path('article/<slug>/', ArticleSlugView.as_view(), name='article-slug-test-view'),
 
     # An URL with view-kwargs
-    url(
-        r'^tests/kwargs-view/$', auth_views.PasswordResetView.as_view(), {
+    path(
+        'tests/kwargs-view/', auth_views.PasswordResetView.as_view(), {
             'password_reset_form': PasswordResetForm,
             'post_reset_redirect': reverse_lazy('password-reset-done')
         },
         name='view-kwargs-test-view'
     ),
-    url(r'^password-reset/done/$', auth_views.PasswordResetDoneView.as_view(), name='password-reset-done'),
+    path('password-reset/done/', auth_views.PasswordResetDoneView.as_view(), name='password-reset-done'),
 ]
 
 urlpatterns = i18n_patterns(*urls)

--- a/parler/tests/utils.py
+++ b/parler/tests/utils.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 
 from django.apps import apps

--- a/parler/tests/utils.py
+++ b/parler/tests/utils.py
@@ -29,17 +29,17 @@ class override_parler_settings(override_settings):
     """
 
     def __init__(self, **kwargs):
-        super(override_parler_settings, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.old_values = {}
 
     def enable(self):
-        super(override_parler_settings, self).enable()
+        super().enable()
         for key, value in self.options.items():
             self.old_values[key] = getattr(appsettings, key)
             setattr(appsettings, key, value)
 
     def disable(self):
-        super(override_parler_settings, self).disable()
+        super().disable()
         for key in self.options.keys():
             setattr(appsettings, key, self.old_values[key])
 
@@ -54,12 +54,12 @@ class AppTestCase(TestCase):
     )
 
     def setUp(self):
-        super(AppTestCase, self).setUp()
+        super().setUp()
         cache.clear()
 
     @classmethod
     def setUpClass(cls):
-        super(AppTestCase, cls).setUpClass()
+        super().setUpClass()
 
         from django.template.loaders import app_directories  # late import, for django 1.7
         if cls.install_apps:

--- a/parler/utils/conf.py
+++ b/parler/utils/conf.py
@@ -189,15 +189,10 @@ def get_parler_languages_from_django_cms(cms_languages=None):
     valid_keys = ['code', 'fallbacks', 'hide_untranslated',
                   'redirect_on_fallback']
     if cms_languages:
-        if sys.version_info < (3, 0, 0):
-            int_types = (int, long)
-        else:
-            int_types = int
-
         parler_languages = copy.deepcopy(cms_languages)
         for site_id, site_config in cms_languages.items():
             if site_id and (
-                    not isinstance(site_id, int_types) and
+                    not isinstance(site_id, int) and
                     site_id != 'default'
             ):
                 del parler_languages[site_id]

--- a/parler/utils/conf.py
+++ b/parler/utils/conf.py
@@ -5,7 +5,6 @@ The configuration wrappers that are used for :ref:`PARLER_LANGUAGES`.
 import copy
 import sys
 
-import six
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from parler.utils.i18n import is_supported_django_language, get_null_language_error, get_language
@@ -70,7 +69,7 @@ def add_default_language_settings(languages_list, var_name='PARLER_LANGUAGES', *
     if not is_supported_django_language(defaults['code']):
         raise ImproperlyConfigured("The value for {0}['defaults']['code'] ('{1}') does not exist in LANGUAGES".format(var_name, defaults['code']))
 
-    for site_id, lang_choices in six.iteritems(languages_list):
+    for site_id, lang_choices in languages_list.items():
         if site_id == 'default':
             continue
 
@@ -81,7 +80,7 @@ def add_default_language_settings(languages_list, var_name='PARLER_LANGUAGES', *
                 raise ImproperlyConfigured("{0}[{1}][{2}]['code'] does not exist in LANGUAGES".format(var_name, site_id, i))
 
             # Copy all items from the defaults, so you can provide new fields too.
-            for key, value in six.iteritems(defaults):
+            for key, value in defaults.items():
                 choice.setdefault(key, value)
 
     return languages_list

--- a/parler/utils/context.py
+++ b/parler/utils/context.py
@@ -9,7 +9,7 @@ __all__ = (
 )
 
 
-class smart_override(object):
+class smart_override:
     """
     This is a smarter version of :func:`translation.override <django.utils.translation.override>`
     which avoids switching the language if there is no change to make.
@@ -43,7 +43,7 @@ class smart_override(object):
             activate(self.old_language)
 
 
-class switch_language(object):
+class switch_language:
     """
     A contextmanager to switch the translation of an object.
 

--- a/parler/utils/i18n.py
+++ b/parler/utils/i18n.py
@@ -3,7 +3,7 @@ Utils for translations
 """
 from django.conf import settings
 from django.conf.global_settings import LANGUAGES as ALL_LANGUAGES
-from django.utils.translation import ugettext_lazy as _, get_language as dj_get_language
+from django.utils.translation import gettext_lazy as _, get_language as dj_get_language
 
 
 __all__ = (

--- a/parler/utils/template.py
+++ b/parler/utils/template.py
@@ -1,4 +1,3 @@
-import six
 from django.template import TemplateDoesNotExist
 from django.template.loader import get_template
 
@@ -22,7 +21,7 @@ def select_template_name(template_name_list, using=None):
             except TemplateDoesNotExist:
                 continue
             else:
-                template_name = six.text_type(template_name)  # consistent value for lazy() function.
+                template_name = str(template_name)  # consistent value for lazy() function.
                 _cached_name_lookups[template_name_list] = template_name
                 return template_name
 

--- a/parler/utils/views.py
+++ b/parler/utils/views.py
@@ -78,4 +78,4 @@ class TabsList(list):
         self.css_class = css_class
         self.current_is_translated = False
         self.allow_deletion = False
-        super(TabsList, self).__init__(seq)
+        super().__init__(seq)

--- a/parler/views.py
+++ b/parler/views.py
@@ -131,7 +131,7 @@ class TranslatableSlugMixin(object):
 
     def dispatch(self, request, *args, **kwargs):
         try:
-            return super(TranslatableSlugMixin, self).dispatch(request, *args, **kwargs)
+            return super().dispatch(request, *args, **kwargs)
         except FallbackLanguageResolved as e:
             # Handle the fallback language redirect for get_object()
             with switch_language(e.object, e.correct_language):
@@ -206,7 +206,7 @@ class LanguageChoiceMixin(object):
         """
         Assign the language for the retrieved object.
         """
-        object = super(LanguageChoiceMixin, self).get_object(queryset)
+        object = super().get_object(queryset)
         if isinstance(object, TranslatableModelMixin):
             object.set_current_language(self.get_language(), initialize=True)
         return object
@@ -236,7 +236,7 @@ class LanguageChoiceMixin(object):
             return self.get_language()
 
     def get_context_data(self, **kwargs):
-        context = super(LanguageChoiceMixin, self).get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
         context['language_tabs'] = self.get_language_tabs()
         return context
 
@@ -270,7 +270,7 @@ class TranslatableModelFormMixin(LanguageChoiceMixin):
         """
         Return a ``TranslatableModelForm`` by default if no form_class is set.
         """
-        super_method = super(TranslatableModelFormMixin, self).get_form_class
+        super_method = super().get_form_class
         # no "__func__" on the class level function in python 3
         default_method = getattr(ModelFormMixin.get_form_class, '__func__', ModelFormMixin.get_form_class)
         if not (super_method.__func__ is default_method):
@@ -292,7 +292,7 @@ class TranslatableModelFormMixin(LanguageChoiceMixin):
         """
         Pass the current language to the form.
         """
-        kwargs = super(TranslatableModelFormMixin, self).get_form_kwargs()
+        kwargs = super().get_form_kwargs()
         # The TranslatableAdmin can set form.language_code, because the modeladmin always creates a fresh subclass.
         # If that would be done here, the original globally defined form class would be updated.
         kwargs['_current_language'] = self.get_form_language()

--- a/parler/views.py
+++ b/parler/views.py
@@ -38,7 +38,7 @@ __all__ = (
 )
 
 
-class ViewUrlMixin(object):
+class ViewUrlMixin:
     """
     Provide a ``view.get_view_url`` method in the template.
 
@@ -90,7 +90,7 @@ class ViewUrlMixin(object):
         return reverse(self.view_url_name, args=self.args, kwargs=self.kwargs)
 
 
-class TranslatableSlugMixin(object):
+class TranslatableSlugMixin:
     """
     An enhancement for the :class:`~django.views.generic.DetailView` to deal with translated slugs.
     This view makes sure that:
@@ -195,7 +195,7 @@ class FallbackLanguageResolved(Exception):
         self.correct_language = correct_language
 
 
-class LanguageChoiceMixin(object):
+class LanguageChoiceMixin:
     """
     Mixin to add language selection support to class based views, particularly create and update views.
     It adds support for the ``?language=..`` parameter in the query string, and tabs in the context.

--- a/parler/views.py
+++ b/parler/views.py
@@ -13,7 +13,6 @@ The following views are available:
 * :class:`TranslatableCreateView` - The :class:`~django.views.generic.edit.CreateView` with :class:`TranslatableModelFormMixin` support.
 * :class:`TranslatableUpdateView` - The :class:`~django.views.generic.edit.UpdateView` with :class:`TranslatableModelFormMixin` support.
 """
-from __future__ import unicode_literals
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 from django.forms.models import modelform_factory
 from django.http import Http404, HttpResponsePermanentRedirect

--- a/parler/views.py
+++ b/parler/views.py
@@ -165,7 +165,7 @@ class TranslatableSlugMixin(object):
 
         if obj is None:
             tried_msg = ", tried languages: {0}".format(", ".join(choices))
-            error_message = translation.ugettext("No %(verbose_name)s found matching the query") % {'verbose_name': queryset.model._meta.verbose_name}
+            error_message = translation.gettext("No %(verbose_name)s found matching the query") % {'verbose_name': queryset.model._meta.verbose_name}
             raise Http404(error_message + tried_msg)
 
         # Object found!

--- a/parler/widgets.py
+++ b/parler/widgets.py
@@ -34,7 +34,7 @@ __all__ = (
 )
 
 
-class SortedChoiceIterator(object):
+class SortedChoiceIterator:
 
     def __init__(self, field):
         self.field = field
@@ -47,7 +47,7 @@ class SortedChoiceIterator(object):
         return iter(self.field._choices)
 
 
-class SortedSelectMixin(object):
+class SortedSelectMixin:
     """
     A mixin to have the choices sorted by (translated) title.
     """

--- a/parler/widgets.py
+++ b/parler/widgets.py
@@ -53,7 +53,7 @@ class SortedSelectMixin(object):
     """
 
     def __init__(self, attrs=None, choices=()):
-        super(SortedSelectMixin, self).__init__(attrs, choices=())
+        super().__init__(attrs, choices=())
         self._choices = choices   # super may set self.choices=()
         self._sorted = False
 

--- a/parler/widgets.py
+++ b/parler/widgets.py
@@ -4,7 +4,7 @@ These widgets perform sorting on the choices within Python.
 This is useful when sorting is hard to due translated fields, for example:
 
 * the ORM can't sort it.
-* the ordering depends on ``ugettext()`` output.
+* the ordering depends on ``gettext()`` output.
 * the model ``__unicode__()`` value depends on translated fields.
 
 Use them like any regular form widget::

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
 
     install_requires=['six'],
     requires=[
-        'Django (>=1.7)',
+        'Django (>=2.0)',
     ],
 
     description='Simple Django model translations without nasty hacks, featuring nice admin integration.',
@@ -66,15 +66,15 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Application Frameworks',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     license='Apache 2.0',
 
     requires=[
-        'Django (>=2.0)',
+        'Django (>=2.2)',
     ],
 
     description='Simple Django model translations without nasty hacks, featuring nice admin integration.',
@@ -69,8 +69,6 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Framework :: Django',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
     version=find_version('parler', '__init__.py'),
     license='Apache 2.0',
 
-    install_requires=['six'],
     requires=[
         'Django (>=2.0)',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,14 @@
 [tox]
 envlist=
-    py36-django{20,21,22,30,31},
-    py37-django{20,21,22,30,31},
-    py38-django{20,21,22,30,31},
+    py36-django{22,30,31},
+    py37-django{22,30,31},
+    py38-django{22,30,31},
     # py33-django-dev,
     coverage,
     docs,
 
 [testenv]
 deps = django-polymorphic
-    django20: Django >= 2.0,<2.1
-    django21: Django >= 2.1,<2.2
     django22: Django >= 2.2,<2.3
     django30: Django >= 3.0,<3.1
     django31: Django >= 3.1,<3.2
@@ -29,7 +27,7 @@ commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 [testenv:coverage]
 basepython=python3.6
 deps=
-    django==2.0
+    django==3.0
     coverage==4.4.1
 commands=
     coverage erase

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,19 @@
 [tox]
 envlist=
-    py27-django{111},
-    py36-django{111,20,21,22,30},
-    py37-django{20,21,22,30},
+    py36-django{20,21,22,30,31},
+    py37-django{20,21,22,30,31},
+    py38-django{20,21,22,30,31},
     # py33-django-dev,
     coverage,
     docs,
 
 [testenv]
 deps = django-polymorphic
-    django111: Django >= 1.11,<1.12
     django20: Django >= 2.0,<2.1
     django21: Django >= 2.1,<2.2
     django22: Django >= 2.2,<2.3
     django30: Django >= 3.0,<3.1
+    django31: Django >= 3.1,<3.2
     django-dev: https://github.com/django/django/tarball/master
 commands=
     python runtests.py


### PR DESCRIPTION
This is an extended version of #274 that removes all python2 compatibility code.

I have not much experience with metaclasses, so someone smarter than me should check if this requires a migration or something.