### PR TITLE
rm deprecated providing_args from signals

### DIFF
--- a/parler/signals.py
+++ b/parler/signals.py
@@ -7,11 +7,11 @@ Use the signals as last resort, or to maintain separation of concerns.
 """
 from django.dispatch import Signal
 
-pre_translation_init = Signal(providing_args=["instance", "args", "kwargs"])
-post_translation_init = Signal(providing_args=["instance"])
+pre_translation_init = Signal()
+post_translation_init = Signal()
 
-pre_translation_save = Signal(providing_args=["instance", "raw", "using"])
-post_translation_save = Signal(providing_args=["instance", "raw", "created", "using"])
+pre_translation_save = Signal()
+post_translation_save = Signal()
 
-pre_translation_delete = Signal(providing_args=["instance", "using"])
-post_translation_delete = Signal(providing_args=["instance", "using"])
+pre_translation_delete = Signal()
+post_translation_delete = Signal()


### PR DESCRIPTION
see https://docs.djangoproject.com/en/3.1/internals/deprecation/#deprecation-removed-in-4-0