### PR TITLE
Replace outdated compatibility documentation with reference to tox.ini

### DIFF
--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -1,10 +1,7 @@
 Django compatibility
 ====================
 
-This package has been tested with:
-
-* Django versions 1.7 up to 1.11
-* Python versions 2.7 up to 3.6
+Compatible versions of Python and Django are listed in `the tox.ini file <https://github.com/django-parler/django-parler/blob/master/tox.ini>`_.
 
 .. _orm-restrictions:
 


### PR DESCRIPTION
Hi, 

Thanks for maintaining django-parler! We already use it on one of our projects, and more are to come.

I'd like to propose a small documentation improvement: One of my colleagues almost thought django-parler was not compatible with our proposed Django version, because he only looked at https://django-parler.readthedocs.io/en/stable/compatibility.html which lists "Django up to 1.11". This is obviously outdated. In this PR, we replace this with a link to tox.ini. 

Hopefully this will be useful. Thanks in advance for reviewing!