### PR TITLE
Remove reference to .min Django admin static files

### DIFF
--- a/parler/admin.py
+++ b/parler/admin.py
@@ -82,7 +82,7 @@ _language_media = Media(css={
 
 _language_prepopulated_media = _language_media + Media(js=(
     'admin/js/urlify.js',
-    'admin/js/prepopulate{}.js'.format('' if settings.DEBUG else '.min'),
+    'admin/js/prepopulate.js'
 ))
 
 _fakeRequest = HttpRequest()


### PR DESCRIPTION
[Django 3.2+ no longer ships with .min-ified files.](https://docs.djangoproject.com/en/3.2/releases/3.2/#id1)

Checking Django version to keep serving .min-files to older Django versions seems more trouble than it's worth: the non-minified file is just 1.5 kb, gzipped via e.g. nginx 551 bytes.