### PR TITLE
runtests: Add dummy SECRET_KEY

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -74,7 +74,7 @@ if not settings.configured:
         ),
         ROOT_URLCONF = 'example.urls',
         TEST_RUNNER = 'django.test.runner.DiscoverRunner',
-
+        SECRET_KEY = "secret",
         SITE_ID = 4,
         LANGUAGE_CODE = 'en',
         LANGUAGES = (


### PR DESCRIPTION
Closes https://github.com/django-parler/django-parler/issues/296