### PR TITLE
Handle ManyToManyFields

### DIFF
--- a/parler/cache.py
+++ b/parler/cache.py
@@ -149,7 +149,7 @@ def _cache_translation(translation, timeout=cache.default_timeout):
 
     # Cache a translation object.
     # For internal usage, object parameters are not suited for outside usage.
-    fields = translation.get_translated_fields()
+    fields = translation.get_translated_fields(exclude_many_to_many=True)
     values = {'id': translation.id}
     for name in fields:
         values[name] = getattr(translation, name)

--- a/parler/models.py
+++ b/parler/models.py
@@ -58,7 +58,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, ValidationError, FieldError, ObjectDoesNotExist
 from django.db import models, router
 from django.db.models.base import ModelBase
-from django.db.models.fields.related_descriptors import ForwardManyToOneDescriptor
+from django.db.models.fields.related_descriptors import ForwardManyToOneDescriptor, ManyToManyDescriptor
 from django.utils.encoding import force_text
 from django.utils.functional import lazy
 from django.utils.translation import gettext, gettext_lazy as _
@@ -269,7 +269,7 @@ class TranslatableModelMixin:
                 try:
                     setattr(translation, field, value)
                 except TypeError:
-                    # TypeError signals a many to many field. We can't store it like a normal field, so
+                    # TypeError signals a many to many field. We can't set it like the other attributes, so
                     # add to our own glued variable.
                     deferred_many_to_many = getattr(translation, "deferred_many_to_many", {})
                     deferred_many_to_many[field] = value
@@ -647,6 +647,7 @@ class TranslatableModelMixin:
         # Even worse: mptt 0.7 injects this parameter when it avoids updating the lft/rgt fields,
         # but that misses all the translated fields.
         kwargs.pop('update_fields', None)
+
         self.save_translations(*args, **kwargs)
 
     def delete(self, using=None):

--- a/parler/tests/test_model_many_to_many.py
+++ b/parler/tests/test_model_many_to_many.py
@@ -1,0 +1,76 @@
+from .utils import AppTestCase
+
+from .testapp.models import RegularModel, ManyToManyOnlyFieldsTranslationModel, ManyToManyAndOtherFieldsTranslationModel
+
+
+class ModelManyToManyTestCase(AppTestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.regular_one = RegularModel.objects.create(original_field="One")
+        cls.regular_two = RegularModel.objects.create(original_field="Two")
+
+    def test_save_many_to_many_only(self):
+        """Test a model that has *only* translated many to many fields.
+        """
+        obj = ManyToManyOnlyFieldsTranslationModel.objects.create(shared="One")
+
+        # Set many to many for English
+        obj.set_current_language("en")
+        obj.create_translation("en")
+        obj.translated_many_to_many.set([self.regular_one])
+        obj.save()
+        self.assertEqual(
+            ManyToManyOnlyFieldsTranslationModel.objects.language("en").first().translated_many_to_many.all()[0],
+            self.regular_one
+        )
+
+        # Set many to many for French
+        obj.set_current_language("fr")
+        obj.create_translation("fr")
+        obj.translated_many_to_many.set([self.regular_two])
+        obj.save()
+        self.assertEqual(
+            ManyToManyOnlyFieldsTranslationModel.objects.language("fr").first().translated_many_to_many.all()[0],
+            self.regular_two
+        )
+
+        # Check fallback
+        self.assertEqual(
+            ManyToManyOnlyFieldsTranslationModel.objects.language("nl").first().translated_many_to_many.all()[0],
+            self.regular_one
+        )
+
+    def test_save_many_to_many_and_other_fields(self):
+        """Test a model that has *only* translated many to many fields.
+        """
+        obj = ManyToManyAndOtherFieldsTranslationModel.objects.create(shared="One")
+
+        # Set many to many for English
+        obj.set_current_language("en")
+        obj.tr_title = "English"
+        obj.save()
+        obj.translated_many_to_many.set([self.regular_one])
+        obj.save()
+        self.assertEqual(
+            ManyToManyAndOtherFieldsTranslationModel.objects.language("en").first().translated_many_to_many.all()[0],
+            self.regular_one
+        )
+
+        # Set many to many for French
+        obj.set_current_language("fr")
+        obj.tr_title = "French"
+        obj.save()
+        obj.translated_many_to_many.set([self.regular_two])
+        obj.save()
+        self.assertEqual(
+            ManyToManyAndOtherFieldsTranslationModel.objects.language("fr").first().translated_many_to_many.all()[0],
+            self.regular_two
+        )
+
+        # Check fallback
+        self.assertEqual(
+            ManyToManyAndOtherFieldsTranslationModel.objects.language("nl").first().translated_many_to_many.all()[0],
+            self.regular_one
+        )

--- a/parler/tests/testapp/models.py
+++ b/parler/tests/testapp/models.py
@@ -204,6 +204,21 @@ class ForeignKeyTranslationModel(TranslatableModel):
     shared = models.CharField(max_length=200)
 
 
+class ManyToManyOnlyFieldsTranslationModel(TranslatableModel):
+    translations = TranslatedFields(
+        translated_many_to_many = models.ManyToManyField('RegularModel'),
+    )
+    shared = models.CharField(max_length=200)
+
+
+class ManyToManyAndOtherFieldsTranslationModel(TranslatableModel):
+    translations = TranslatedFields(
+        tr_title = models.CharField("Translated Title", max_length=200),
+        translated_many_to_many = models.ManyToManyField('RegularModel'),
+    )
+    shared = models.CharField(max_length=200)
+
+
 class TranslationRelated(TranslatableModel):
     shared = models.CharField(max_length=200)
     translation_relations = TranslatedField()


### PR DESCRIPTION
This PR adds the ability to translate ManyToManyFields. ManyToManyFields are tricky because they don't support setting the instance attribute directly.

M2M fields can now be declared within the `translations` section on a model. They now also appear on update forms.

Docs will need updating to explain the edge case where *all* the translated fields on a model are ManyToManyFields. In such a case some required setters won't fire.

Finally, as usually happens with these types of PR's the tests are way longer than the actual code.