### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -3,7 +3,7 @@ Performance guidelines
 
 The translations of each model is stored in a separate table.
 In some cases, this may cause in N-query issue.
-*django-parler* offers two ways to handle the performance of the dabase.
+*django-parler* offers two ways to handle the performance of the database.
 
 Caching
 -------

--- a/docs/templatetags.rst
+++ b/docs/templatetags.rst
@@ -37,7 +37,7 @@ The ``get_translated_url`` tag can be used to get the proper URL for this page i
 If the URL could not be generated, an empty string is returned instead.
 
 This algorithm performs a "best effort" approach to give a proper URL.
-When this fails, add the :class:`~parler.views.ViewUrlMixin` to your view to contruct the proper URL instead.
+When this fails, add the :class:`~parler.views.ViewUrlMixin` to your view to construct the proper URL instead.
 
 Example, to build a language menu:
 

--- a/parler/tests/test_forms.py
+++ b/parler/tests/test_forms.py
@@ -188,10 +188,10 @@ class FormTests(AppTestCase):
         r1 = RegularModel.objects.create(original_field="r1")
         a = ForeignKeyTranslationModel.objects.create(translated_foreign=r1, shared="EN")
 
-        # same way as TranslatableAdmin.get_object() inicializing translation, when user switch to new translation language
+        # same way as TranslatableAdmin.get_object() initializing translation, when user switch to new translation language
         a.set_current_language("fr", initialize=True)
 
-        # inicialize form
+        # initialize form
         form = ForeignKeyTranslationModelForm(instance=a)
 
         self.assertTrue(True)
@@ -203,7 +203,7 @@ class FormTests(AppTestCase):
         self.assertEqual("label:shared", form_instance["shared"].label)
         self.assertEqual("label:tr_title", form_instance["tr_title"].label)
 
-        # Override error messsages
+        # Override error messages
         form_instance = OverrideMetaFieldForm(
             _current_language="fr-FR",
             data={

--- a/parler/tests/test_model_attributes.py
+++ b/parler/tests/test_model_attributes.py
@@ -246,7 +246,7 @@ class ModelAttributeTests(AppTestCase):
             )
             self.assertIs(
                 x.safe_translation_getter("tr_title", "DEFAULT"), "DEFAULT"
-            )  # No lanuage, gives default
+            )  # No language, gives default
             self.assertEqual(
                 x.safe_translation_getter("tr_title", any_language=True), "TITLE_XX"
             )  # Even though there is no current language, there is a value.


### PR DESCRIPTION
There are small typos in:
- docs/performance.rst
- docs/templatetags.rst
- parler/tests/test_forms.py
- parler/tests/test_model_attributes.py

Fixes:
- Should read `messages` rather than `messsages`.
- Should read `language` rather than `lanuage`.
- Should read `initializing` rather than `inicializing`.
- Should read `initialize` rather than `inicialize`.
- Should read `database` rather than `dabase`.
- Should read `construct` rather than `contruct`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md