### PR TITLE
Use translation._state.adding to detect if value is new

### DIFF
--- a/parler/models.py
+++ b/parler/models.py
@@ -789,7 +789,7 @@ class TranslatableModelMixin:
         # Translation models without any fields are also supported.
         # This is useful for parent objects that have inlines;
         # the parent object defines how many translations there are.
-        if translation.pk is None or translation.is_modified:
+        if translation._state.adding or translation.is_modified:
             if not translation.master_id:  # Might not exist during first construction
                 translation._state.db = self._state.db
                 translation.master = self


### PR DESCRIPTION
If you are using UUID primary fields as outlined here https://docs.djangoproject.com/en/3.2/ref/models/fields/#uuidfield for the translated fields then testing `pk is None` is not a valid way to identify if objects are being created, it should be using `_state.adding`