### PR TITLE
Permit Field Name Conflicts To Ease Existing Field Migrations

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,38 +16,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Django 2.2
-          # - django: "2.2"
-          #   python: "3.6"
-          # - django: "2.2"
-          #   python: "3.7"
-          # - django: "2.2"
-          #   python: "3.8"
-          # - django: "2.2"
-          #   python: "3.9"
-          # # Django 3.1
-          # - django: "3.1"
-          #   python: "3.6"
-          # - django: "3.1"
-          #   python: "3.7"
-          # - django: "3.1"
-          #   python: "3.8"
-          # - django: "3.1"
-          #   python: "3.9"
-          # # Django 3.2
-          # - django: "3.2"
-          #   python: "3.6"
-          # - django: "3.2"
-          #   python: "3.7"
-          # - django: "3.2"
-          #   python: "3.8"
-          # - django: "3.2"
-          #   python: "3.9"
-          # - django: "3.2"
-          #   python: "3.10"
           # Django 4.2
           - django: "4.2"
             python: "3.9"
+          - django: "4.2"
+            python: "3.10"
+          # Django 5.0
+          - django: "5.0"
+            python: "3.10"
 
     steps:
       - name: Install gettext
@@ -71,3 +47,4 @@ jobs:
           echo "Python ${{ matrix.python }} / Django ${{ matrix.django }}"
           coverage run --rcfile=.coveragerc runtests.py
           codecov
+        continue-on-error: ${{ contains(matrix.django, '5.0') }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,37 +17,37 @@ jobs:
       matrix:
         include:
           # Django 2.2
-          - django: "2.2"
-            python: "3.6"
-          - django: "2.2"
-            python: "3.7"
-          - django: "2.2"
-            python: "3.8"
-          - django: "2.2"
+          # - django: "2.2"
+          #   python: "3.6"
+          # - django: "2.2"
+          #   python: "3.7"
+          # - django: "2.2"
+          #   python: "3.8"
+          # - django: "2.2"
+          #   python: "3.9"
+          # # Django 3.1
+          # - django: "3.1"
+          #   python: "3.6"
+          # - django: "3.1"
+          #   python: "3.7"
+          # - django: "3.1"
+          #   python: "3.8"
+          # - django: "3.1"
+          #   python: "3.9"
+          # # Django 3.2
+          # - django: "3.2"
+          #   python: "3.6"
+          # - django: "3.2"
+          #   python: "3.7"
+          # - django: "3.2"
+          #   python: "3.8"
+          # - django: "3.2"
+          #   python: "3.9"
+          # - django: "3.2"
+          #   python: "3.10"
+          # Django 4.2
+          - django: "4.2"
             python: "3.9"
-          # Django 3.1
-          - django: "3.1"
-            python: "3.6"
-          - django: "3.1"
-            python: "3.7"
-          - django: "3.1"
-            python: "3.8"
-          - django: "3.1"
-            python: "3.9"
-          # Django 3.2
-          - django: "3.2"
-            python: "3.6"
-          - django: "3.2"
-            python: "3.7"
-          - django: "3.2"
-            python: "3.8"
-          - django: "3.2"
-            python: "3.9"
-          - django: "3.2"
-            python: "3.10"
-          # Django 4.0
-          - django: "4.0b1"
-            python: "3.10"
 
     steps:
       - name: Install gettext
@@ -71,4 +71,3 @@ jobs:
           echo "Python ${{ matrix.python }} / Django ${{ matrix.django }}"
           coverage run --rcfile=.coveragerc runtests.py
           codecov
-        continue-on-error: ${{ contains(matrix.django, '4.0') }}

--- a/docs/advanced/migrating.rst
+++ b/docs/advanced/migrating.rst
@@ -32,6 +32,11 @@ First create the translatable fields::
               name=models.CharField(max_length=123),
         )
 
+
+Then enable ``PARLER_PERMIT_FIELD_NAME_CONFLICTS`` in your project settings:
+
+    PARLER_PERMIT_FIELD_NAME_CONFLICTS = True
+
 Now create the migration::
 
     manage.py makemigrations myapp --name "add_translation_model"
@@ -117,6 +122,10 @@ The example model now looks like::
 Create the database migration, it will simply remove the original field::
 
     manage.py makemigrations myapp --name "remove_untranslated_fields"
+
+Disable ``PARLER_PERMIT_FIELD_NAME_CONFLICTS`` in your project settings:
+
+    PARLER_PERMIT_FIELD_NAME_CONFLICTS = False
 
 
 Updating code

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -146,3 +146,14 @@ PARLER_DEFAULT_ACTIVATE
     PARLER_DEFAULT_ACTIVATE = True
 
 Setting, which allows to display translated texts in the default language even through ``translation.activate()`` is not called yet.
+
+
+PARLER_PERMIT_FIELD_NAME_CONFLICTS
+----------------------------------
+
+::
+
+    PARLER_PERMIT_FIELD_NAME_CONFLICTS = False
+
+Setting which enables translation models to have the same field names as the parent model by not creating proxy fields. This should
+only be enabled when writing migrating existing fields.

--- a/parler/appsettings.py
+++ b/parler/appsettings.py
@@ -34,3 +34,7 @@ PARLER_LANGUAGES = add_default_language_settings(PARLER_LANGUAGES)
 
 # Activate translations by default. Flag to compensate for Django >= 1.8 default `get_language` behavior
 PARLER_DEFAULT_ACTIVATE = getattr(settings, "PARLER_DEFAULT_ACTIVATE", False)
+
+# Permit the models and translation models to have conflicting keys (advertently does not instantiate proxy fields).
+# This is useful for migrating existing fields with data. 
+PARLER_PERMIT_FIELD_NAME_CONFLICTS = getattr(settings, "PARLER_PERMIT_FIELD_NAME_CONFLICTS", False)

--- a/parler/fields.py
+++ b/parler/fields.py
@@ -61,6 +61,13 @@ class TranslationsForeignKey(models.ForeignKey):
 
         super().contribute_to_related_class(cls, related)
         _validate_master(self.model)
+
+        # Skip contributing proxy fields to the shared model 
+        # during `migrate` or `makemigration` as historical models
+        # may not have the `TranslatedModel` base.
+        if cls.__module__ == "__fake__":
+            return
+
         if issubclass(self.model, TranslatedFieldsModelMixin):
             self.model.contribute_translations(cls)
 

--- a/parler/models.py
+++ b/parler/models.py
@@ -325,7 +325,7 @@ class TranslatableModelMixin:
                     # See: https://github.com/django-parler/django-parler/issues/326
                     model_field = parler_meta.model._meta.get_field(field)
                     model_field.save_form_data(translation, value)
-                except TypeError:
+                except (ValueError, TypeError) as e:
                     # TypeError signals a many to many field. We can't set it like the other attributes, so
                     # add to our own glued variable.
                     deferred_many_to_many = getattr(translation, "deferred_many_to_many", {})

--- a/parler/models.py
+++ b/parler/models.py
@@ -321,7 +321,10 @@ class TranslatableModelMixin:
             )
             for field, value in model_fields.items():
                 try:
-                    setattr(translation, field, value)
+                    # Fixed FileField clearing.
+                    # See: https://github.com/django-parler/django-parler/issues/326
+                    model_field = parler_meta.model._meta.get_field(field)
+                    model_field.save_form_data(translation, value)
                 except TypeError:
                     # TypeError signals a many to many field. We can't set it like the other attributes, so
                     # add to our own glued variable.

--- a/parler/models.py
+++ b/parler/models.py
@@ -1085,6 +1085,9 @@ class TranslatedFieldsModelMixin:
                 # A model field might not be added yet, as this all happens in the contribute_to_class() loop.
                 # Hence, only checking attributes here. The real fields are checked for in the _prepare() code.
                 shared_field = getattr(shared_model, name)
+                
+                # Other libraries/plugins may manage the field, such as `model_utils.FieldTracker`, therefore, attempt to bypass this.
+                shared_field = shared_field.descirptor if hasattr(shared_field, "descriptor") else shared_field
             except AttributeError:
                 # Add the proxy field for the shared field.
                 TranslatedField().contribute_to_class(shared_model, name)

--- a/parler/models.py
+++ b/parler/models.py
@@ -1085,9 +1085,9 @@ class TranslatedFieldsModelMixin:
                 # A model field might not be added yet, as this all happens in the contribute_to_class() loop.
                 # Hence, only checking attributes here. The real fields are checked for in the _prepare() code.
                 shared_field = getattr(shared_model, name)
-                
+
                 # Other libraries/plugins may manage the field, such as `model_utils.FieldTracker`, therefore, attempt to bypass this.
-                shared_field = shared_field.descirptor if hasattr(shared_field, "descriptor") else shared_field
+                shared_field = shared_field.descriptor if hasattr(shared_field, "descriptor") else shared_field
             except AttributeError:
                 # Add the proxy field for the shared field.
                 TranslatedField().contribute_to_class(shared_model, name)

--- a/parler/models.py
+++ b/parler/models.py
@@ -730,30 +730,6 @@ class TranslatableModelMixin:
         _delete_cached_translations(self)
         return super().delete(using)
 
-    def validate_unique(self, exclude=None):
-        """
-        Also validate the unique_together of the translated model.
-        """
-        # This is called from ModelForm._post_clean() or Model.full_clean()
-        errors = {}
-        try:
-            super().validate_unique(exclude=exclude)
-        except ValidationError as e:
-            errors = e.error_dict
-
-        for local_cache in self._translations_cache.values():
-            for translation in local_cache.values():
-                if is_missing(translation):  # Skip fallback markers
-                    continue
-
-                try:
-                    translation.validate_unique(exclude=exclude)
-                except ValidationError as e:
-                    errors.update(e.error_dict)
-
-        if errors:
-            raise ValidationError(errors)
-
     def save_translations(self, *args, **kwargs):
         """
         The method to save all translations.

--- a/parler/tests/testapp/models.py
+++ b/parler/tests/testapp/models.py
@@ -44,6 +44,16 @@ class CleanFieldModel(TranslatableModel):
     def clean(self):
         self.shared += "_cleanshared"
 
+class FileFieldModel(TranslatableModel):
+    translations = TranslatedFields(
+        tr_file=models.FileField(
+            default="",
+            blank=True,
+        )
+    )
+
+    def __str__(self):
+        return self.tr_file
 
 class CleanFieldModelTranslation(TranslatedFieldsModel):
     master = TranslationsForeignKey(


### PR DESCRIPTION
### Summary

This PR is to enable easier migration of existing fields by disabling the proxy fields using a new setting, `PARLER_PERMIT_FIELD_NAME_CONFLICTS`.

### Further Information

* The documentation for [making existing fields translatable](https://django-parler.readthedocs.io/en/stable/advanced/migrating.html) does not work when executing the `makemigration` command, as an error is thrown with the message `The model '{shared_model.__name__}' already has a field named '{name}'`.

* The proposal is to skip this error and not contribute the proxy class only when the `PARLER_PERMIT_FIELD_NAME_CONFLICTS` setting is `True`. This means the "old field" can exist, while the `django-parler` schema can be created. Translations from `django-parler` must be sourced from the `translations` relationship.

* This enables a developer to perform a 3-step zero downtime migration, or slowly roll in `django-parler`.

### Issues

Closes #263
Closes #254