### PR TITLE
Fallback to first site_id when current site_id is not in PARLER_SETTINGS

### DIFF
--- a/parler/utils/conf.py
+++ b/parler/utils/conf.py
@@ -172,6 +172,29 @@ class LanguagesSetting(dict):
         else:
             return None
 
+    def get(self, site_id, default=None):
+        """
+        Return the language settings for the current site.
+        If not found, return the first defined setting.
+        Useful for dynamic multi-site configurations.
+        """
+        site_language_setting = super().get(site_id, default)
+        if not site_language_setting and isinstance(site_id, int) and not default:
+            return next((value for key, value in self.items() if isinstance(key, int)), None)
+        return site_language_setting
+
+    def __getitem__(self, site_id):
+        """
+        Return the language settings for the current site.
+        If not found, return the first defined setting.
+        Useful for dynamic multi-site configurations.
+        """
+        return self.get(site_id, None)
+
+    def get_site_language_dicts(self):
+        site_id = getattr(settings, "SITE_ID", None)
+        return self.get(site_id)
+
     def get_default_language(self):
         """
         Return the default language.

--- a/parler/utils/i18n.py
+++ b/parler/utils/i18n.py
@@ -105,7 +105,7 @@ def is_multilingual_project(site_id=None):
     if site_id is None:
         site_id = getattr(settings, "SITE_ID", None)
     return (
-        appsettings.PARLER_SHOW_EXCLUDED_LANGUAGE_TABS or site_id in appsettings.PARLER_LANGUAGES
+        appsettings.PARLER_SHOW_EXCLUDED_LANGUAGE_TABS or appsettings.PARLER_LANGUAGES.get(site_id)
     )
 
 

--- a/parler/utils/views.py
+++ b/parler/utils/views.py
@@ -1,8 +1,6 @@
 """
 Internal DRY functions.
 """
-from django.conf import settings
-
 from parler import appsettings
 from parler.utils import get_language_title, is_multilingual_project, normalize_language_code
 
@@ -37,8 +35,7 @@ def get_language_tabs(request, current_language, available_languages, css_class=
     get = request.GET.copy()  # QueryDict object
     tab_languages = []
 
-    site_id = getattr(settings, "SITE_ID", None)
-    for lang_dict in appsettings.PARLER_LANGUAGES.get(site_id, ()):
+    for lang_dict in appsettings.PARLER_LANGUAGES.get_site_language_dicts():
         code = lang_dict["code"]
         title = get_language_title(code)
         get["language"] = code


### PR DESCRIPTION
Some projects have multi-site setup where sites can be added dynamically at run time, and the new sites end up with their SITE_ID not present in PARLER_LANGUAGES. This makes the language tabs in the admin pages not show for thew newly added sites.

This fix adds a fallback in these situations, where if the current SITE_ID is not present in PARLER_LANGUAGES, the first defined site_id in PARLER_LANGUAGES will be used.