### PR TITLE
Fix - check cache before clear

### DIFF
--- a/parler/models.py
+++ b/parler/models.py
@@ -848,7 +848,8 @@ class TranslatableModelMixin:
     def refresh_from_db(self, *args, **kwargs):
         super().refresh_from_db(*args, **kwargs)
         _delete_cached_translations(self)
-        self._translations_cache.clear()
+        if self._translations_cache:
+            self._translations_cache.clear()
 
     refresh_from_db.alters_data = True
 


### PR DESCRIPTION
When attempting to use dumpdata on an M2M with a translated field, the refresh_from_db method raised an error.

_translations_cache was None, leading to an AttributeError: 'NoneType' object has no attribute 'clear'.
 
```python
Traceback (most recent call last):
  File "/app/manage.py", line 31, in <module>
    execute_from_command_line(sys.argv)
  File "/app/.scalingo/python/lib/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/app/.scalingo/python/lib/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/app/.scalingo/python/lib/python3.12/site-packages/django/core/management/base.py", line 413, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/app/.scalingo/python/lib/python3.12/site-packages/django/core/management/base.py", line 459, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.scalingo/python/lib/python3.12/site-packages/django/core/management/commands/dumpdata.py", line 268, in handle
    serializers.serialize(
  File "/app/.scalingo/python/lib/python3.12/site-packages/django/core/serializers/__init__.py", line 134, in serialize
    s.serialize(queryset, **options)
  File "/app/.scalingo/python/lib/python3.12/site-packages/django/core/serializers/base.py", line 144, in serialize
    self.handle_m2m_field(obj, field)
  File "/app/.scalingo/python/lib/python3.12/site-packages/django/core/serializers/python.py", line 93, in handle_m2m_field
    self._current[field.name] = [m2m_value(related) for related in m2m_iter]
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.scalingo/python/lib/python3.12/site-packages/django/db/models/query.py", line 518, in _iterator
    yield from iterable
  File "/app/.scalingo/python/lib/python3.12/site-packages/django/db/models/query.py", line 124, in __iter__
    obj = model_cls.from_db(
          ^^^^^^^^^^^^^^^^^^
  File "/app/.scalingo/python/lib/python3.12/site-packages/django/db/models/base.py", line 582, in from_db
    new = cls(*values)
          ^^^^^^^^^^^^
  File "/app/.scalingo/python/lib/python3.12/site-packages/parler/models.py", line 292, in __init__
    super().__init__(*args, **kwargs)
  File "/app/.scalingo/python/lib/python3.12/site-packages/ordered_model/models.py", line 127, in __init__
    self._original_wrt_map = self._wrt_map()
                             ^^^^^^^^^^^^^^^
  File "/app/.scalingo/python/lib/python3.12/site-packages/ordered_model/models.py", line 134, in _wrt_map
    d[order_wrt_name] = get_lookup_value(self, field_path)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.scalingo/python/lib/python3.12/site-packages/ordered_model/models.py", line 15, in get_lookup_value
    return reduce(lambda i, f: getattr(i, f), field.split(LOOKUP_SEP), obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.scalingo/python/lib/python3.12/site-packages/ordered_model/models.py", line 15, in <lambda>
    return reduce(lambda i, f: getattr(i, f), field.split(LOOKUP_SEP), obj)
                               ^^^^^^^^^^^^^
  File "/app/.scalingo/python/lib/python3.12/site-packages/django/db/models/query_utils.py", line 219, in __get__
    instance.refresh_from_db(fields=[field_name])
  File "/app/.scalingo/python/lib/python3.12/site-packages/parler/models.py", line 851, in refresh_from_db
    self._translations_cache.clear()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'clear'
```