### PR TITLE
Add Auto-Translation Support to TranslateableAdmin using DEEPL API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -191,10 +191,12 @@ Django parler can be configured to use DEEPL API to suggest translations with a 
 You can get a free or pro deepl api key and start translating with a click in your admin dashboard.
 
 .. code-block:: python
+
     PARLER_ALLOW_AUTO_TRANSLATION = True
     DEEPL_API_KEY = 'your-deepl-api-key'
 
-Add these settings in your django settings file and parler should show buttons for translation suggestions
+Add these settings in your django settings file and parler should show buttons for translation suggestions.
+
 Attention: This feature requires python requests library.
 
 Advanced Features

--- a/README.rst
+++ b/README.rst
@@ -185,6 +185,17 @@ And a function to query just a specific field:
 
     model.safe_translation_getter('title', language_code='fr')
 
+Auto translation using DEEPL
+-----------------
+Django parler can be configured to use DEEPL API to suggest translations with a click.
+You can get a free or pro deepl api key and start translating with a click in your admin dashboard.
+
+.. code-block:: python
+    PARLER_ALLOW_AUTO_TRANSLATION = True
+    DEEPL_API_KEY = 'your-deepl-api-key'
+
+Add these settings in your django settings file and parler should show buttons for translation suggestions
+Attention: This feature requires python requests library.
 
 Advanced Features
 -----------------

--- a/parler/appsettings.py
+++ b/parler/appsettings.py
@@ -1,6 +1,7 @@
 """
 Overview of all settings which can be customized.
 """
+
 from django.conf import settings
 
 from parler.utils import get_parler_languages_from_django_cms, normalize_language_code
@@ -37,4 +38,4 @@ PARLER_DEFAULT_ACTIVATE = getattr(settings, "PARLER_DEFAULT_ACTIVATE", False)
 
 
 PARLER_ALLOW_AUTO_TRANSLATION = getattr(settings, "PARLER_ALLOW_AUTO_TRANSLATION", False)
-PARLER_DEEPL_API_KEY = getattr(settings, "PARLER_DEEPL_API_KEY", None)
+PARLER_DEEPL_API_KEY = getattr(settings, "DEEPL_API_KEY", None)

--- a/parler/appsettings.py
+++ b/parler/appsettings.py
@@ -34,3 +34,7 @@ PARLER_LANGUAGES = add_default_language_settings(PARLER_LANGUAGES)
 
 # Activate translations by default. Flag to compensate for Django >= 1.8 default `get_language` behavior
 PARLER_DEFAULT_ACTIVATE = getattr(settings, "PARLER_DEFAULT_ACTIVATE", False)
+
+
+PARLER_ALLOW_AUTO_TRANSLATION = getattr(settings, "PARLER_ALLOW_AUTO_TRANSLATION", False)
+PARLER_DEEPL_API_KEY = getattr(settings, "PARLER_DEEPL_API_KEY", None)

--- a/parler/templates/admin/parler/change_form.html
+++ b/parler/templates/admin/parler/change_form.html
@@ -65,6 +65,16 @@
             for (const property in data.translations) {
                 document.getElementById(`id_${property}`).value = data.translations[property];
             }
+            for (const inline in data.inline_translations) {
+                value = data.inline_translations[inline];
+                for (const index in value) {
+                    for (const property in value[index]) {
+                        document.getElementById(`id_${inline}s-${index}-${property}`).value = value[index][property];
+                    }
+
+                }
+                
+            }
         }
     </script>
 {% endif %}

--- a/parler/templates/admin/parler/change_form.html
+++ b/parler/templates/admin/parler/change_form.html
@@ -1,17 +1,42 @@
 {% extends default_change_form_template|default:"admin/change_form.html" %}
 {% load i18n %}
+
+
+{% block extrahead %}
+{{block.super}}
+{% if suggest_translations %}    
+<style>
+    .object-tools li {
+        float:right;
+    }
+    .object-tools li.new-row {
+        float: none;
+        clear: both;
+        margin-top: 2.5rem;
+    }
+</style>
+{% endif %}
+{% endblock extrahead %}
+
+    
+
+
 {% block object-tools-items %}
-<li>
+{{block.super}}
+{% if suggest_translations %}    
+<li class="new-row">
+    <span style="float: left;line-height: 1.65rem;margin-right: 0.5rem;">Copy translations from:</span>
     {% for url,name,code,status in language_tabs %}
         {% if status == "available" %}
-            <a href="./suggest-translation/{{ code }}/" class="copy-translations-link">
+            <a href="./suggest-translation/{{ code }}/" class="copy-translations-link" style="margin-left: 0.25rem">
                 {{code}}
             </a>
         {% endif %}
     {% endfor %}   
 </li>
-{{block.super}}
+{% endif %}
 {% endblock %}
+
 {% block field_sets %}
 {% if language_tabs %}{% include "admin/parler/language_tabs.html" %}{% endif %}
 {{ block.super }}
@@ -19,7 +44,8 @@
 
 
 {% block admin_change_form_document_ready %}
-   {{block.super}}
+{{block.super}}
+{% if suggest_translations %}
     <script>
         
         {% for url,name,code,status in language_tabs %}
@@ -41,4 +67,5 @@
             }
         }
     </script>
+{% endif %}
 {% endblock %}

--- a/parler/templates/admin/parler/change_form.html
+++ b/parler/templates/admin/parler/change_form.html
@@ -1,6 +1,44 @@
 {% extends default_change_form_template|default:"admin/change_form.html" %}
-
+{% load i18n %}
+{% block object-tools-items %}
+<li>
+    {% for url,name,code,status in language_tabs %}
+        {% if status == "available" %}
+            <a href="./suggest-translation/{{ code }}/" class="copy-translations-link">
+                {{code}}
+            </a>
+        {% endif %}
+    {% endfor %}   
+</li>
+{{block.super}}
+{% endblock %}
 {% block field_sets %}
 {% if language_tabs %}{% include "admin/parler/language_tabs.html" %}{% endif %}
 {{ block.super }}
+{% endblock %}
+
+
+{% block admin_change_form_document_ready %}
+   {{block.super}}
+    <script>
+        
+        {% for url,name,code,status in language_tabs %}
+            {% if status == "current" %}
+                let targetLanguage = "{{code}}";
+            {% endif %}
+        {% endfor %} 
+        document.addEventListener("click", (e) => {
+            if (e.target.classList.contains("copy-translations-link")) {
+                e.preventDefault();
+                fetch(`${e.target.href}?targetLanguage=${targetLanguage}`)
+                .then(res => res.json())
+                .then(data => suggestTranslations(data))
+            }
+        })
+        function suggestTranslations(data) {
+            for (const property in data.translations) {
+                document.getElementById(`id_${property}`).value = data.translations[property];
+            }
+        }
+    </script>
 {% endblock %}

--- a/parler/templates/admin/parler/change_form.html
+++ b/parler/templates/admin/parler/change_form.html
@@ -63,13 +63,17 @@
         })
         function suggestTranslations(data) {
             for (const property in data.translations) {
-                document.getElementById(`id_${property}`).value = data.translations[property];
+                let field = document.getElementById(`id_${property}`);
+                field.value = data.translations[property];
+                field.dispatchEvent(new CustomEvent('change'));
             }
             for (const inline in data.inline_translations) {
                 value = data.inline_translations[inline];
                 for (const index in value) {
                     for (const property in value[index]) {
-                        document.getElementById(`id_${inline}s-${index}-${property}`).value = value[index][property];
+                        let field = document.getElementById(`id_${inline}s-${index}-${property}`);
+                        field.value = value[index][property];
+                        field.dispatchEvent(new CustomEvent('change'));
                     }
 
                 }

--- a/parler/utils/views.py
+++ b/parler/utils/views.py
@@ -1,6 +1,7 @@
 """
 Internal DRY functions.
 """
+
 from django.conf import settings
 from parler import appsettings
 from parler.utils import get_language_title, is_multilingual_project, normalize_language_code
@@ -37,7 +38,7 @@ def get_language_tabs(request, current_language, available_languages, css_class=
     tab_languages = []
 
     site_id = getattr(settings, "SITE_ID", None)
-    
+
     for lang_dict in appsettings.PARLER_LANGUAGES.get(site_id, ()):
         code = lang_dict["code"]
         title = get_language_title(code)
@@ -84,6 +85,7 @@ class TabsList(list):
 
 def translate_by_deepl(texts, source_language, target_language, auth_key):
     import requests
+
     if auth_key.lower().endswith(":fx"):
         endpoint = "https://api-free.deepl.com"
     else:
@@ -98,4 +100,7 @@ def translate_by_deepl(texts, source_language, target_language, auth_key):
             "text": texts,
         },
     )
-    return r.json()
+    if r.status_code == 200:
+        return r.json()
+    else:
+        return {}

--- a/parler/utils/views.py
+++ b/parler/utils/views.py
@@ -2,7 +2,6 @@
 Internal DRY functions.
 """
 from django.conf import settings
-
 from parler import appsettings
 from parler.utils import get_language_title, is_multilingual_project, normalize_language_code
 
@@ -38,6 +37,7 @@ def get_language_tabs(request, current_language, available_languages, css_class=
     tab_languages = []
 
     site_id = getattr(settings, "SITE_ID", None)
+    
     for lang_dict in appsettings.PARLER_LANGUAGES.get(site_id, ()):
         code = lang_dict["code"]
         title = get_language_title(code)
@@ -67,7 +67,7 @@ def get_language_tabs(request, current_language, available_languages, css_class=
                     status = "available"
 
                 tabs.append((url, get_language_title(code), code, status))
-
+    tabs.available_languages = available_languages
     tabs.current_is_translated = current_language in available_languages
     tabs.allow_deletion = len(available_languages) > 1
     return tabs
@@ -78,4 +78,24 @@ class TabsList(list):
         self.css_class = css_class
         self.current_is_translated = False
         self.allow_deletion = False
+        self.available_languages = []
         super().__init__(seq)
+
+
+def translate_by_deepl(texts, source_language, target_language, auth_key):
+    import requests
+    if auth_key.lower().endswith(":fx"):
+        endpoint = "https://api-free.deepl.com"
+    else:
+        endpoint = "https://api.deepl.com"
+
+    r = requests.post(
+        f"{endpoint}/v2/translate",
+        headers={"Authorization": f"DeepL-Auth-Key {auth_key}"},
+        data={
+            "target_lang": target_language.upper(),
+            "source_lang": source_language.upper(),
+            "text": texts,
+        },
+    )
+    return r.json()

--- a/parler/views.py
+++ b/parler/views.py
@@ -13,6 +13,7 @@ The following views are available:
 * :class:`TranslatableCreateView` - The :class:`~django.views.generic.edit.CreateView` with :class:`TranslatableModelFormMixin` support.
 * :class:`TranslatableUpdateView` - The :class:`~django.views.generic.edit.UpdateView` with :class:`TranslatableModelFormMixin` support.
 """
+
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 from django.forms.models import modelform_factory
 from django.http import Http404, HttpResponsePermanentRedirect
@@ -26,6 +27,7 @@ from parler.models import TranslatableModelMixin
 from parler.utils import get_active_language_choices
 from parler.utils.context import switch_language
 from parler.utils.views import get_language_parameter, get_language_tabs
+from parler import appsettings
 
 __all__ = (
     "ViewUrlMixin",


### PR DESCRIPTION
**Description:**

This pull request introduces auto-translation support for the TranslateableAdmin within the django-parler. The current implementation supports only the DeepL API but it should be easy to add support for other translation service providers if needed.

**Key Features:**

1.  Auto-Translation: Automatically translates translatable fields in the admin interface using the DeepL API.
2.  Admin Interface Integration: Adds "Copy translations from..." buttons for ease of use.
3. Dependency: Requires the requests library for API interactions.
4. Pre-Save Verification: Allows users to review and verify translations before saving.

**Setup Instructions:**

    Set the PARLER_ALLOW_AUTO_TRANSLATION setting to True in your Django settings.
    Provide a valid DEEPL_API_KEY in your environment or settings file. (free version or any pro versions work)

These settings will enable the auto-translation feature and display the "Copy translations from..." buttons in the admin interface.
![image](https://github.com/user-attachments/assets/b493a0d9-a9bd-4961-bbb0-92bf2987a3b9)